### PR TITLE
[Post BazelBuilder refactor part 2] TargetsRuleResolver

### DIFF
--- a/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers/ActionGraphParser.java
+++ b/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers/ActionGraphParser.java
@@ -31,8 +31,7 @@ public class ActionGraphParser {
             })
         .map(artifact -> "exec-root://" + artifact.getExecPath())
         .filter(path -> suffixes.stream().anyMatch(path::endsWith))
-        .collect(Collectors.toCollection(TreeSet::new))
-        .stream()
+        .distinct()
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers/ActionGraphParser.java
+++ b/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers/ActionGraphParser.java
@@ -7,7 +7,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 import org.jetbrains.bsp.bazel.commons.Uri;
 

--- a/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers/TargetRulesResolver.java
+++ b/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers/TargetRulesResolver.java
@@ -11,28 +11,28 @@ import org.jetbrains.bsp.bazel.server.bazel.BazelRunner;
 import org.jetbrains.bsp.bazel.server.bazel.data.BazelProcessResult;
 import org.jetbrains.bsp.bazel.server.bazel.params.BazelRunnerFlag;
 
-public class TargetsRulesResolver<T> {
+public class TargetRulesResolver<T> {
 
   private final BazelRunner bazelRunner;
 
   private final Predicate<Build.Rule> filter;
   private final Function<Build.Rule, T> mapper;
 
-  private TargetsRulesResolver(
+  private TargetRulesResolver(
       BazelRunner bazelRunner, Predicate<Build.Rule> filter, Function<Rule, T> mapper) {
     this.bazelRunner = bazelRunner;
     this.filter = filter;
     this.mapper = mapper;
   }
 
-  public static <T> TargetsRulesResolver<T> withBazelRunnerAndMapper(
+  public static <T> TargetRulesResolver<T> withBazelRunnerAndMapper(
       BazelRunner bazelRunner, Function<Rule, T> mapper) {
     return withBazelRunnerAndFilterAndMapper(bazelRunner, o -> true, mapper);
   }
 
-  public static <T> TargetsRulesResolver<T> withBazelRunnerAndFilterAndMapper(
+  public static <T> TargetRulesResolver<T> withBazelRunnerAndFilterAndMapper(
       BazelRunner bazelRunner, Predicate<Build.Rule> filter, Function<Rule, T> mapper) {
-    return new TargetsRulesResolver<T>(bazelRunner, filter, mapper);
+    return new TargetRulesResolver<T>(bazelRunner, filter, mapper);
   }
 
   public List<T> getItemsForTargets(List<BuildTargetIdentifier> targetsIds) {

--- a/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers/TargetsLanguageOptionsResolver.java
+++ b/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers/TargetsLanguageOptionsResolver.java
@@ -14,9 +14,10 @@ import org.jetbrains.bsp.bazel.server.bazel.data.BazelData;
 import org.jetbrains.bsp.bazel.server.bazel.data.BazelProcessResult;
 import org.jetbrains.bsp.bazel.server.bazel.params.BazelRunnerFlag;
 
-public class TargetsResolver<T> {
+public class TargetsLanguageOptionsResolver<T> {
 
   private static final List<String> ACTION_GRAPH_SUFFIXES = ImmutableList.of(".jar", ".js");
+
   private final BazelData bazelData;
   private final BazelRunner bazelRunner;
   private final ActionGraphResolver actionGraphResolver;
@@ -24,7 +25,7 @@ public class TargetsResolver<T> {
   private final List<String> languagesIds;
   private final ResultItemsCollector<T> resultItemsCollector;
 
-  private TargetsResolver(
+  private TargetsLanguageOptionsResolver(
       BazelData bazelData,
       BazelRunner bazelRunner,
       String compilerOptionsName,
@@ -154,10 +155,10 @@ public class TargetsResolver<T> {
       return this;
     }
 
-    public TargetsResolver<T> build() {
+    public TargetsLanguageOptionsResolver<T> build() {
       throwExceptionIfAnyFieldIsNotFilled();
 
-      return new TargetsResolver<T>(
+      return new TargetsLanguageOptionsResolver<T>(
           bazelData, bazelRunner, compilerOptionsName, languagesIds, resultItemsCollector);
     }
 

--- a/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers/TargetsRulesResolver.java
+++ b/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers/TargetsRulesResolver.java
@@ -1,0 +1,68 @@
+package org.jetbrains.bsp.bazel.server.bsp.resolvers;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import com.google.devtools.build.lib.query2.proto.proto2api.Build;
+import com.google.devtools.build.lib.query2.proto.proto2api.Build.Rule;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.jetbrains.bsp.bazel.server.bazel.BazelRunner;
+import org.jetbrains.bsp.bazel.server.bazel.data.BazelProcessResult;
+import org.jetbrains.bsp.bazel.server.bazel.params.BazelRunnerFlag;
+
+public class TargetsRulesResolver<T> {
+
+  private final BazelRunner bazelRunner;
+
+  private final Predicate<Build.Rule> filter;
+  private final Function<Build.Rule, T> mapper;
+
+  private TargetsRulesResolver(
+      BazelRunner bazelRunner,
+      Predicate<Build.Rule> filter,
+      Function<Rule, T> mapper) {
+    this.bazelRunner = bazelRunner;
+    this.filter = filter;
+    this.mapper = mapper;
+  }
+
+  public static <T> TargetsRulesResolver<T> withBazelRunnerAndMapper(
+      BazelRunner bazelRunner,
+      Function<Rule, T> mapper) {
+    return withBazelRunnerAndFilterAndMapper(bazelRunner, o -> true, mapper);
+  }
+
+  public static <T> TargetsRulesResolver<T> withBazelRunnerAndFilterAndMapper(
+      BazelRunner bazelRunner,
+      Predicate<Build.Rule> filter,
+      Function<Rule, T> mapper) {
+    return new TargetsRulesResolver<T>(bazelRunner, filter, mapper);
+  }
+
+  public List<T> getItemsForTargets(List<BuildTargetIdentifier> targetsIds) {
+    Build.QueryResult queryResult = getBuildQueryResult(targetsIds);
+
+    return queryResult.getTargetList().stream()
+        .map(Build.Target::getRule)
+        .filter(filter)
+        .map(mapper)
+        .collect(Collectors.toList());
+  }
+
+  private Build.QueryResult getBuildQueryResult(List<BuildTargetIdentifier> targetsIds) {
+    List<String> targets = TargetsUtils.getTargetsUris(targetsIds);
+    BazelProcessResult bazelProcessResult = queryBazel(targets);
+
+    return QueryResolver.getQueryResultForProcess(bazelProcessResult);
+  }
+
+  private BazelProcessResult queryBazel(List<String> targets) {
+    return bazelRunner
+        .commandBuilder()
+        .query()
+        .withFlag(BazelRunnerFlag.OUTPUT_PROTO)
+        .withTargets(targets)
+        .executeBazelCommand();
+  }
+}

--- a/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers/TargetsRulesResolver.java
+++ b/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers/TargetsRulesResolver.java
@@ -19,24 +19,19 @@ public class TargetsRulesResolver<T> {
   private final Function<Build.Rule, T> mapper;
 
   private TargetsRulesResolver(
-      BazelRunner bazelRunner,
-      Predicate<Build.Rule> filter,
-      Function<Rule, T> mapper) {
+      BazelRunner bazelRunner, Predicate<Build.Rule> filter, Function<Rule, T> mapper) {
     this.bazelRunner = bazelRunner;
     this.filter = filter;
     this.mapper = mapper;
   }
 
   public static <T> TargetsRulesResolver<T> withBazelRunnerAndMapper(
-      BazelRunner bazelRunner,
-      Function<Rule, T> mapper) {
+      BazelRunner bazelRunner, Function<Rule, T> mapper) {
     return withBazelRunnerAndFilterAndMapper(bazelRunner, o -> true, mapper);
   }
 
   public static <T> TargetsRulesResolver<T> withBazelRunnerAndFilterAndMapper(
-      BazelRunner bazelRunner,
-      Predicate<Build.Rule> filter,
-      Function<Rule, T> mapper) {
+      BazelRunner bazelRunner, Predicate<Build.Rule> filter, Function<Rule, T> mapper) {
     return new TargetsRulesResolver<T>(bazelRunner, filter, mapper);
   }
 

--- a/src/main/java/org/jetbrains/bsp/bazel/server/bsp/services/BuildServerService.java
+++ b/src/main/java/org/jetbrains/bsp/bazel/server/bsp/services/BuildServerService.java
@@ -51,7 +51,7 @@ import org.jetbrains.bsp.bazel.server.bsp.BazelBspServerBuildManager;
 import org.jetbrains.bsp.bazel.server.bsp.BazelBspServerLifetime;
 import org.jetbrains.bsp.bazel.server.bsp.BazelBspServerRequestHelpers;
 import org.jetbrains.bsp.bazel.server.bsp.resolvers.QueryResolver;
-import org.jetbrains.bsp.bazel.server.bsp.resolvers.TargetsRulesResolver;
+import org.jetbrains.bsp.bazel.server.bsp.resolvers.TargetRulesResolver;
 import org.jetbrains.bsp.bazel.server.bsp.resolvers.TargetsUtils;
 
 public class BuildServerService {
@@ -138,11 +138,11 @@ public class BuildServerService {
   }
 
   public Either<ResponseError, SourcesResult> buildTargetSources(SourcesParams sourcesParams) {
-    TargetsRulesResolver<SourcesItem> targetsRulesResolver =
-        TargetsRulesResolver.withBazelRunnerAndMapper(bazelRunner, this::mapBuildRuleToSourcesItem);
+    TargetRulesResolver<SourcesItem> targetRulesResolver =
+        TargetRulesResolver.withBazelRunnerAndMapper(bazelRunner, this::mapBuildRuleToSourcesItem);
 
     List<SourcesItem> sourceItems =
-        targetsRulesResolver.getItemsForTargets(sourcesParams.getTargets());
+        targetRulesResolver.getItemsForTargets(sourcesParams.getTargets());
 
     SourcesResult sourcesResult = new SourcesResult(sourceItems);
 

--- a/src/main/java/org/jetbrains/bsp/bazel/server/bsp/services/BuildServerService.java
+++ b/src/main/java/org/jetbrains/bsp/bazel/server/bsp/services/BuildServerService.java
@@ -29,6 +29,7 @@ import ch.epfl.scala.bsp4j.TestParams;
 import ch.epfl.scala.bsp4j.TestProvider;
 import ch.epfl.scala.bsp4j.TestResult;
 import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.query2.proto.proto2api.Build;
 import java.util.ArrayList;
@@ -50,6 +51,7 @@ import org.jetbrains.bsp.bazel.server.bsp.BazelBspServerBuildManager;
 import org.jetbrains.bsp.bazel.server.bsp.BazelBspServerLifetime;
 import org.jetbrains.bsp.bazel.server.bsp.BazelBspServerRequestHelpers;
 import org.jetbrains.bsp.bazel.server.bsp.resolvers.QueryResolver;
+import org.jetbrains.bsp.bazel.server.bsp.resolvers.TargetsRulesResolver;
 import org.jetbrains.bsp.bazel.server.bsp.resolvers.TargetsUtils;
 
 public class BuildServerService {
@@ -136,36 +138,38 @@ public class BuildServerService {
   }
 
   public Either<ResponseError, SourcesResult> buildTargetSources(SourcesParams sourcesParams) {
-    List<String> targets = TargetsUtils.getTargetsUris(sourcesParams.getTargets());
+    TargetsRulesResolver<SourcesItem> targetsRulesResolver =
+        TargetsRulesResolver.withBazelRunnerAndMapper(bazelRunner, this::mapBuildRuleToSourcesItem);
 
-    BazelProcessResult bazelProcessResult =
-        bazelRunner
-            .commandBuilder()
-            .query()
-            .withFlag(BazelRunnerFlag.OUTPUT_PROTO)
-            .withTargets(targets)
-            .executeBazelCommand();
+    List<SourcesItem> sourceItems =
+        targetsRulesResolver.getItemsForTargets(sourcesParams.getTargets());
 
-    Build.QueryResult queryResult = QueryResolver.getQueryResultForProcess(bazelProcessResult);
+    SourcesResult sourcesResult = new SourcesResult(sourceItems);
 
-    List<SourcesItem> sources =
-        queryResult.getTargetList().stream()
-            .map(Build.Target::getRule)
-            .map(
-                rule -> {
-                  BuildTargetIdentifier label = new BuildTargetIdentifier(rule.getName());
-                  List<SourceItem> items = serverBuildManager.getSourceItems(rule, label);
-                  List<String> roots =
-                      Lists.newArrayList(
-                          Uri.fromAbsolutePath(serverBuildManager.getSourcesRoot(rule.getName()))
-                              .toString());
-                  SourcesItem item = new SourcesItem(label, items);
-                  item.setRoots(roots);
-                  return item;
-                })
-            .collect(Collectors.toList());
+    return Either.forRight(sourcesResult);
+  }
 
-    return Either.forRight(new SourcesResult(sources));
+  private SourcesItem mapBuildRuleToSourcesItem(Build.Rule rule) {
+    BuildTargetIdentifier ruleLabel = new BuildTargetIdentifier(rule.getName());
+    List<SourceItem> items = serverBuildManager.getSourceItems(rule, ruleLabel);
+    List<String> roots = getRuleRoots(rule);
+
+    return createSourcesForLabelAndItemsAndRoots(ruleLabel, items, roots);
+  }
+
+  private List<String> getRuleRoots(Build.Rule rule) {
+    String sourcesRootUriString = serverBuildManager.getSourcesRoot(rule.getName());
+    Uri uri = Uri.fromAbsolutePath(sourcesRootUriString);
+
+    return ImmutableList.of(uri.toString());
+  }
+
+  private SourcesItem createSourcesForLabelAndItemsAndRoots(
+      BuildTargetIdentifier label, List<SourceItem> items, List<String> roots) {
+    SourcesItem item = new SourcesItem(label, items);
+    item.setRoots(roots);
+
+    return item;
   }
 
   public Either<ResponseError, InverseSourcesResult> buildTargetInverseSources(

--- a/src/main/java/org/jetbrains/bsp/bazel/server/bsp/services/JavaBuildServerService.java
+++ b/src/main/java/org/jetbrains/bsp/bazel/server/bsp/services/JavaBuildServerService.java
@@ -10,7 +10,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.jetbrains.bsp.bazel.commons.Constants;
 import org.jetbrains.bsp.bazel.server.bazel.BazelRunner;
 import org.jetbrains.bsp.bazel.server.bazel.data.BazelData;
-import org.jetbrains.bsp.bazel.server.bsp.resolvers.TargetsResolver;
+import org.jetbrains.bsp.bazel.server.bsp.resolvers.TargetsLanguageOptionsResolver;
 
 public class JavaBuildServerService {
 
@@ -19,11 +19,11 @@ public class JavaBuildServerService {
   private static final List<String> JAVA_LANGUAGES_IDS =
       ImmutableList.of(Constants.JAVAC, Constants.KOTLINC);
 
-  private final TargetsResolver<JavacOptionsItem> targetsResolver;
+  private final TargetsLanguageOptionsResolver<JavacOptionsItem> targetsLanguageOptionsResolver;
 
   public JavaBuildServerService(BazelData bazelData, BazelRunner bazelRunner) {
-    this.targetsResolver =
-        TargetsResolver.<JavacOptionsItem>builder()
+    this.targetsLanguageOptionsResolver =
+        TargetsLanguageOptionsResolver.<JavacOptionsItem>builder()
             .bazelData(bazelData)
             .bazelRunner(bazelRunner)
             .compilerOptionsName(JAVA_COMPILER_OPTIONS_NAME)
@@ -35,7 +35,7 @@ public class JavaBuildServerService {
   public Either<ResponseError, JavacOptionsResult> buildTargetJavacOptions(
       JavacOptionsParams javacOptionsParams) {
     List<JavacOptionsItem> resultItems =
-        targetsResolver.getResultItemsForTargets(javacOptionsParams.getTargets());
+        targetsLanguageOptionsResolver.getResultItemsForTargets(javacOptionsParams.getTargets());
 
     JavacOptionsResult javacOptionsResult = new JavacOptionsResult(resultItems);
     return Either.forRight(javacOptionsResult);

--- a/src/main/java/org/jetbrains/bsp/bazel/server/bsp/services/ScalaBuildServerService.java
+++ b/src/main/java/org/jetbrains/bsp/bazel/server/bsp/services/ScalaBuildServerService.java
@@ -16,7 +16,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.jetbrains.bsp.bazel.commons.Constants;
 import org.jetbrains.bsp.bazel.server.bazel.BazelRunner;
 import org.jetbrains.bsp.bazel.server.bazel.data.BazelData;
-import org.jetbrains.bsp.bazel.server.bsp.resolvers.TargetsResolver;
+import org.jetbrains.bsp.bazel.server.bsp.resolvers.TargetsLanguageOptionsResolver;
 
 public class ScalaBuildServerService {
 
@@ -24,11 +24,11 @@ public class ScalaBuildServerService {
   private static final List<String> SCALA_LANGUAGES_IDS =
       ImmutableList.of(Constants.SCALAC, Constants.JAVAC);
 
-  private final TargetsResolver<ScalacOptionsItem> targetsResolver;
+  private final TargetsLanguageOptionsResolver<ScalacOptionsItem> targetsLanguageOptionsResolver;
 
   public ScalaBuildServerService(BazelData bazelData, BazelRunner bazelRunner) {
-    this.targetsResolver =
-        TargetsResolver.<ScalacOptionsItem>builder()
+    this.targetsLanguageOptionsResolver =
+        TargetsLanguageOptionsResolver.<ScalacOptionsItem>builder()
             .bazelData(bazelData)
             .bazelRunner(bazelRunner)
             .compilerOptionsName(SCALA_COMPILER_OPTIONS_NAME)
@@ -41,7 +41,7 @@ public class ScalaBuildServerService {
       ScalacOptionsParams scalacOptionsParams) {
 
     List<ScalacOptionsItem> resultItems =
-        targetsResolver.getResultItemsForTargets(scalacOptionsParams.getTargets());
+        targetsLanguageOptionsResolver.getResultItemsForTargets(scalacOptionsParams.getTargets());
 
     ScalacOptionsResult javacOptionsResult = new ScalacOptionsResult(resultItems);
     return Either.forRight(javacOptionsResult);

--- a/src/test/java/org/jetbrains/bsp/bazel/BazelBspServerTest.java
+++ b/src/test/java/org/jetbrains/bsp/bazel/BazelBspServerTest.java
@@ -33,11 +33,11 @@ public class BazelBspServerTest {
   public void run() {
     LOGGER.info("Running BazelBspServerTest...");
 
-    List<BazelBspServerSingleTest> testsTopRun = getTestsTopRun();
+    List<BazelBspServerSingleTest> testsTopRun = getTestsToRun();
     runTests(testsTopRun);
   }
 
-  private List<BazelBspServerSingleTest> getTestsTopRun() {
+  private List<BazelBspServerSingleTest> getTestsToRun() {
     return ImmutableList.of(
         new BazelBspServerSingleTest("resolve project", client::testResolveProject),
         new BazelBspServerSingleTest(


### PR DESCRIPTION
Introducing ... `TargetsRuleResolver`!

It's a tiny change, but it'll be useful in `buildTargetScalaTestClasses` and `buildTargetScalaMainClasses` implementations.

Unfortunately, I tried, but I didn't manage to use it in `buildTargetResources` -- the logic is a bit too complicated, so I decided to leave it in the current state for a while. Nevertheless, I think that introduced mechanism could be extended and used there.

Also I thought that maybe it would be nice to introduce a [command pattern](https://en.wikipedia.org/wiki/Command_pattern) to this project -- api call = class. Logic, mostly, is very independent for every call (with few exceptions) so maybe it'd be nice to encapsulate it and get rid of ~ 400 lines classes. What do you think about it? If you think that it could be a good idea, I'll be able to implement it asap.


NOT RELATED WITH PR BUT I DECIDED TO FIX IT IN THIS PR:
- typo in tests `testsTopRun` -> `testsToRun`
- `ActionGraphParser` logic got simplified a bit -- unnecessary set creation (even intellij marked it)
- rename `TargetsResolver` -> `TargetsLanguageOptionsResolver` -- it's only used in `buildTargetJavacOptions` / `buildTargetScalacOptions`, but I'm still thinks about the best naming convention, any ideas?