### PR TITLE
Prohibit wildcard imports using error-prone

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,5 @@
 build --java_toolchain=@bazel_tools//tools/jdk:toolchain_java8
 build --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java8
+build --javacopt="-Xep:WildcardImport:ERROR"
+test --javacopt="-Xep:WildcardImport:ERROR"
+run --javacopt="-Xep:WildcardImport:ERROR"


### PR DESCRIPTION
So apparently error-prone is built into Bazel and provides a check for wildcard imports.
http://errorprone.info/docs/installation