### PR TITLE
Handle multiple projects in one workspace

### DIFF
--- a/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/BazelRunner.java
+++ b/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/BazelRunner.java
@@ -1,9 +1,13 @@
 package org.jetbrains.bsp.bazel.bazelrunner;
 
+import ch.epfl.scala.bsp4j.StatusCode;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.bsp.bazel.server.loggers.BuildClientLogger;
@@ -19,9 +23,27 @@ public class BazelRunner {
 
   private Optional<Integer> besBackendPort = Optional.empty();
   private Optional<BuildClientLogger> buildClientLogger = Optional.empty();
+  private final Supplier<File> workspaceRoot;
 
   public BazelRunner(String bazelBinaryPath) {
     this.bazel = bazelBinaryPath;
+    this.workspaceRoot = Suppliers.memoize(this::resolveWorkspaceRoot);
+  }
+
+  private File resolveWorkspaceRoot() {
+    var builder = new ProcessBuilder(bazel, "info", "workspace");
+    try {
+      var process = new BazelProcess(builder.start(), Optional.empty());
+      var result = process.waitAndGetResult();
+      if (result.getStatusCode() != StatusCode.OK) {
+        throw new RuntimeException(
+            "Failed to run bazel info workspace. Make sure that the project is created inside a"
+                + " bazel workspace");
+      }
+      return new File(result.getStdout().get(0));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public BazelRunnerCommandBuilder commandBuilder() {
@@ -64,6 +86,7 @@ public class BazelRunner {
     LOGGER.info("Running: {}", processArgs);
 
     ProcessBuilder processBuilder = new ProcessBuilder(processArgs);
+    processBuilder.directory(workspaceRoot.get());
     Process process = processBuilder.start();
 
     return new BazelProcess(process, buildClientLogger);

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/Install.java
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/Install.java
@@ -64,8 +64,7 @@ public class Install {
         Path rootDir = getRootDir(cmd);
         writeConfigurationFiles(rootDir, details);
 
-        String currentDirectory = getCurrentDirectory();
-        System.out.println("Bazel BSP server installed in '" + currentDirectory + "'.");
+        System.out.println("Bazel BSP server installed in '" + rootDir.toAbsolutePath() + "'.");
       }
     } catch (ParseException e) {
       writer.println(e.getMessage());

--- a/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/ProjectViewDefaultParserProvider.java
+++ b/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/ProjectViewDefaultParserProvider.java
@@ -1,8 +1,8 @@
 package org.jetbrains.bsp.bazel.projectview.parser;
 
 import io.vavr.control.Try;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.jetbrains.bsp.bazel.commons.Constants;
 import org.jetbrains.bsp.bazel.projectview.model.ProjectView;
 import org.jetbrains.bsp.bazel.projectview.model.ProjectViewDefaultProvider;
@@ -11,18 +11,19 @@ import org.jetbrains.bsp.bazel.projectview.model.ProjectViewProvider;
 public class ProjectViewDefaultParserProvider implements ProjectViewProvider {
 
   private static final ProjectViewParser PARSER = new ProjectViewParserImpl();
-  private static final Path PROJECT_VIEW_FILE = Paths.get(Constants.DEFAULT_PROJECT_VIEW_FILE);
   private static final ProjectViewProvider PROJECT_VIEW_PROVIDER = new ProjectViewDefaultProvider();
+
+  private final Path projectViewFile;
+
+  public ProjectViewDefaultParserProvider(Path bspProjectRoot) {
+    this.projectViewFile = bspProjectRoot.resolve(Constants.DEFAULT_PROJECT_VIEW_FILE);
+  }
 
   @Override
   public ProjectView create() {
-    return Try.success(PROJECT_VIEW_FILE)
-        .filter(this::doesProjectViewFileExists)
+    return Try.success(projectViewFile)
+        .filter(Files::isRegularFile)
         .mapTry(PARSER::parse)
         .getOrElse(PROJECT_VIEW_PROVIDER::create);
-  }
-
-  private boolean doesProjectViewFileExists(Path projectViewFile) {
-    return projectViewFile.toFile().isFile();
   }
 }

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/ServerInitializer.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/ServerInitializer.java
@@ -33,16 +33,17 @@ public class ServerInitializer {
     ExecutorService executor = Executors.newCachedThreadPool();
 
     try {
-      Path rootDir = Paths.get(Constants.BAZELBSP_DIR_NAME).toAbsolutePath();
+      var bspProjectRoot = Paths.get("").toAbsolutePath();
+      var rootDir = bspProjectRoot.resolve(Constants.BAZELBSP_DIR_NAME);
       Files.createDirectories(rootDir);
 
-      Path traceFile = rootDir.resolve(Constants.BAZELBSP_TRACE_JSON_FILE_NAME);
+      var traceFile = rootDir.resolve(Constants.BAZELBSP_TRACE_JSON_FILE_NAME);
       PrintWriter traceWriter =
           new PrintWriter(
               Files.newOutputStream(
                   traceFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING));
 
-      BazelBspServerConfig bazelBspServerConfig = getBazelBspServerConfig(args);
+      var bazelBspServerConfig = getBazelBspServerConfig(bspProjectRoot, args);
 
       BspIntegrationData bspIntegrationData =
           new BspIntegrationData(stdout, stdin, executor, traceWriter);
@@ -66,23 +67,23 @@ public class ServerInitializer {
     }
   }
 
-  private static BazelBspServerConfig getBazelBspServerConfig(String[] args) {
-    String pathToBazel = args[0];
-    ProjectView projectView = getProjectView(args);
+  private static BazelBspServerConfig getBazelBspServerConfig(Path bspProjectRoot, String[] args) {
+    var pathToBazel = args[0];
+    var projectView = getProjectView(bspProjectRoot, args);
     return new BazelBspServerConfig(pathToBazel, projectView);
   }
 
-  private static ProjectView getProjectView(String[] args) {
-    ProjectViewProvider provider = getProjectViewProvider(args);
+  private static ProjectView getProjectView(Path bspProjectRoot, String[] args) {
+    ProjectViewProvider provider = getProjectViewProvider(bspProjectRoot, args);
 
     return provider.create();
   }
 
-  private static ProjectViewProvider getProjectViewProvider(String[] args) {
+  private static ProjectViewProvider getProjectViewProvider(Path bspProjectRoot, String[] args) {
     if (args.length == 2) {
       return new ServerArgsProjectViewProvider(args[1]);
     }
 
-    return new ProjectViewDefaultParserProvider();
+    return new ProjectViewDefaultParserProvider(bspProjectRoot);
   }
 }

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/bsp/utils/SourceRootGuesserTest.java
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/bsp/utils/SourceRootGuesserTest.java
@@ -31,20 +31,21 @@ public class SourceRootGuesserTest {
   @Parameters
   public static Collection<Object> data() {
     return Arrays.asList(
-        new Object[][] {
-          {
-            "file:///WORKSPACE_ROOT/java_hello/src/main/java/com/hello/Hello.java",
-            "/WORKSPACE_ROOT/java_hello/src/main/java"
-          },
-          {
-            "file:///WORKSPACE_ROOT/server/src/test/java/org/jetbrains/bsp/bazel/server/bsp/utils/SourceRootGuesserTest.java",
-            "/WORKSPACE_ROOT/server/src/test/java"
-          },
-          {
-            "file:///WORKSPACE_ROOT/src/main/java/org/test/java",
-            "/WORKSPACE_ROOT/src/main/java/org/test/java"
-          },
-          {"file:///WORKSPACE_ROOT/foo/bar", "/WORKSPACE_ROOT/foo"}
-        });
+        (Object[])
+            new Object[][] {
+              {
+                "file:///WORKSPACE_ROOT/java_hello/src/main/java/com/hello/Hello.java",
+                "/WORKSPACE_ROOT/java_hello/src/main/java"
+              },
+              {
+                "file:///WORKSPACE_ROOT/server/src/test/java/org/jetbrains/bsp/bazel/server/bsp/utils/SourceRootGuesserTest.java",
+                "/WORKSPACE_ROOT/server/src/test/java"
+              },
+              {
+                "file:///WORKSPACE_ROOT/src/main/java/org/test/java",
+                "/WORKSPACE_ROOT/src/main/java/org/test/java"
+              },
+              {"file:///WORKSPACE_ROOT/foo/bar", "/WORKSPACE_ROOT/foo"}
+            });
   }
 }


### PR DESCRIPTION
Fixes #122.

The goal of this PR is to allow creating the bsp/intellij project root in different location than the repository root.
Example locations could be <REPO>/bsp-projects/<PROJ> or <REPO>/../bsp-projects/<PROJ>.
I imagine it would be used through a wrapper like `bazel idea --bsp --name myproject --targets //target_a/... //target_b/...`, and such wrapper would manage where this directory is, if project already exists, auto generating name and similar things. But first, the server needs to support it.

I made a distinction between `workspace root` (bazel workspace root) and `bsp project root` (root directory for .bsp, .idea, .bazelbsp, projectview.bazelview files). I added workspace root as startup arg of the server and it is set up by the installer. It is used as a directory where bazel is run from. Without this it would work fine if bsp-projects was inside repo root, but if it is outside, it is necessary.

Now by default projectview file is expected to be in the bsp project root.

To use this feature installer should be run from workspace directory as `installer -d bsp-projects/project-name` or `installer -d ~/bsp-projects/project-name -w ~/workspaces/repo` from any directory.

The issue in IntelliJ is that when the workspace and project are in different directories, project tree is not a tree. Instead, each module (except modules inside modules) becomes a root. This lacks context. Ideally we would see the whole repo, or a common parent and all its children that are modules or has modules as children. I made a workaround on `root-module` branch, that creates a fake root module that points to the workspace. I am not opening PR for that because it triggers indexing of whole monorepo and most of files contain highlighting errors. This is thing to resolve later.

This PR depends on Java 11 migration, so I will rebase it after that one is merged.