### PR TITLE
Filter out non runtime jars for running apps and tests

### DIFF
--- a/commons/src/main/java/org/jetbrains/bsp/bazel/commons/Constants.java
+++ b/commons/src/main/java/org/jetbrains/bsp/bazel/commons/Constants.java
@@ -61,7 +61,8 @@ public class Constants {
   public static final String DIAGNOSTICS = "diagnostics";
   public static final String EXEC_ROOT_PREFIX = "exec-root://";
   public static final String SCALA_COMPILER_CLASSPATH_FILES = "scala_compiler_classpath_files";
-  public static final String JAVA_RUNTIME_CLASSPATH_ASPECT_OUTPUT_GROUP = "java_runtime_classpath_files";
+  public static final String JAVA_RUNTIME_CLASSPATH_ASPECT_OUTPUT_GROUP =
+      "java_runtime_classpath_files";
 
   public static final String SCALA_TEST_MAIN_CLASSES_ATTRIBUTE_NAME = "main_class";
 

--- a/commons/src/main/java/org/jetbrains/bsp/bazel/commons/Constants.java
+++ b/commons/src/main/java/org/jetbrains/bsp/bazel/commons/Constants.java
@@ -61,6 +61,7 @@ public class Constants {
   public static final String DIAGNOSTICS = "diagnostics";
   public static final String EXEC_ROOT_PREFIX = "exec-root://";
   public static final String SCALA_COMPILER_CLASSPATH_FILES = "scala_compiler_classpath_files";
+  public static final String JAVA_RUNTIME_CLASSPATH_ASPECT_OUTPUT_GROUP = "java_runtime_classpath_files";
 
   public static final String SCALA_TEST_MAIN_CLASSES_ATTRIBUTE_NAME = "main_class";
 

--- a/e2e/src/main/java/org/jetbrains/bsp/bazel/BazelBspSampleRepoTest.java
+++ b/e2e/src/main/java/org/jetbrains/bsp/bazel/BazelBspSampleRepoTest.java
@@ -320,7 +320,7 @@ public class BazelBspSampleRepoTest extends BazelBspTestBaseScenario {
                     System.getenv())));
 
     return new BazelBspTestScenarioStep(
-        "jvm run environment results",
+        "jvm test environment results",
         () -> testClient.testJvmTestEnvironment(params, expectedResult));
   }
 

--- a/e2e/src/main/java/org/jetbrains/bsp/bazel/base/BazelBspTestBaseScenario.java
+++ b/e2e/src/main/java/org/jetbrains/bsp/bazel/base/BazelBspTestBaseScenario.java
@@ -60,7 +60,11 @@ public abstract class BazelBspTestBaseScenario {
   }
 
   private boolean executeScenarioSteps() {
-    return getScenarioSteps().stream().allMatch(BazelBspTestScenarioStep::executeAndReturnResult);
+    return getScenarioSteps().stream()
+        .map(BazelBspTestScenarioStep::executeAndReturnResult)
+        .collect(java.util.stream.Collectors.toList())
+        .stream()
+        .allMatch(x -> x);
   }
 
   protected abstract List<BazelBspTestScenarioStep> getScenarioSteps();

--- a/e2e/src/main/java/org/jetbrains/bsp/bazel/base/BazelBspTestScenarioStep.java
+++ b/e2e/src/main/java/org/jetbrains/bsp/bazel/base/BazelBspTestScenarioStep.java
@@ -22,7 +22,7 @@ public class BazelBspTestScenarioStep {
 
     return Try.run(testkitCall)
         .onSuccess(e -> LOGGER.info("Step \"{}\" executed correctly!", testName))
-        .onFailure(e -> LOGGER.error("Step \"{}\" execution failed! Exception: {}", testName, e))
+        .onFailure(e -> LOGGER.error("Step \"{}\" execution failed!", testName, e))
         .map(i -> true)
         .getOrElse(false);
   }

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/aspects.bzl
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/aspects.bzl
@@ -29,6 +29,23 @@ scala_compiler_classpath_aspect = aspect(
     implementation = _scala_compiler_classpath_impl,
 )
 
+def _java_runtime_classpath_impl(target, ctx):
+    files = depset()
+    if JavaInfo in target:
+        java_info = target[JavaInfo]
+        files = java_info.compilation_info.runtime_classpath if java_info.compilation_info else java_info.transitive_runtime_jars
+
+    output_file = ctx.actions.declare_file("%s-runtime_classpath.textproto" % target.label.name)
+    ctx.actions.write(output_file, struct(files = [file.path for file in files.to_list()]).to_proto())
+
+    return [
+        OutputGroupInfo(java_runtime_classpath_files = [output_file]),
+    ]
+
+java_runtime_classpath_aspect = aspect(
+    implementation = _java_runtime_classpath_impl,
+)
+
 def _fetch_cpp_compiler(target, ctx):
     if cc_common.CcToolchainInfo in target:
         toolchain_info = target[cc_common.CcToolchainInfo]

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/BazelBspServer.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/BazelBspServer.java
@@ -85,7 +85,8 @@ public class BazelBspServer {
             bazelRunner,
             bazelBspServerConfig.getProjectView());
 
-    JvmBuildServerService jvmBuildServerService = new JvmBuildServerService(bazelData, bazelRunner);
+    JvmBuildServerService jvmBuildServerService =
+        new JvmBuildServerService(bazelData, bazelRunner, bazelBspAspectsManager);
     ScalaBuildServerService scalaBuildServerService =
         new ScalaBuildServerService(
             bazelData, bazelRunner, bazelBspCompilationManager, bazelBspQueryManager);

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/BepServer.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/BepServer.java
@@ -47,6 +47,10 @@ public class BepServer extends PublishBuildEventGrpc.PublishBuildEventImplBase {
       ImmutableList.of("Loading: 0 packages loaded");
 
   private static final int URI_PREFIX_LENGTH = 7;
+  public static final Set<String> EXPECTED_OUTPUT_GROUPS =
+      Set.of(
+          Constants.SCALA_COMPILER_CLASSPATH_FILES,
+          Constants.JAVA_RUNTIME_CLASSPATH_ASPECT_OUTPUT_GROUP);
 
   private final BuildClient bspClient;
   private final BuildClientLogger buildClientLogger;
@@ -168,13 +172,13 @@ public class BepServer extends PublishBuildEventGrpc.PublishBuildEventImplBase {
     LOGGER.info("Consuming target completed event " + targetComplete);
     if (outputGroups.size() == 1) {
       OutputGroup outputGroup = outputGroups.get(0);
-      if (outputGroup.getName().equals(Constants.SCALA_COMPILER_CLASSPATH_FILES)) {
-        fetchScalaJars(outputGroup);
+      if (EXPECTED_OUTPUT_GROUPS.contains(outputGroup.getName())) {
+        fetchOutputGroup(outputGroup);
       }
     }
   }
 
-  private void fetchScalaJars(OutputGroup outputGroup) {
+  private void fetchOutputGroup(OutputGroup outputGroup) {
     outputGroup.getFileSetsList().stream()
         .flatMap(fileSetId -> namedSetsOfFiles.get(fileSetId.getId()).getFilesList().stream())
         .map(file -> URI.create(file.getUri()))

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspAspectsManager.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspAspectsManager.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jetbrains.bsp.bazel.bazelrunner.BazelRunner;
 import org.jetbrains.bsp.bazel.bazelrunner.params.BazelRunnerFlag;
-import org.jetbrains.bsp.bazel.commons.Constants;
 import org.jetbrains.bsp.bazel.commons.Uri;
 import org.jetbrains.bsp.bazel.server.bep.BepServer;
 
@@ -35,7 +34,7 @@ public class BazelBspAspectsManager {
         targets, ImmutableList.of(aspectFlag, outputGroupFlag));
     return bepServer
         .getOutputGroupPaths()
-        .getOrDefault(Constants.SCALA_COMPILER_CLASSPATH_FILES, Collections.emptySet())
+        .getOrDefault(outputGroup, Collections.emptySet())
         .stream()
         .map(Uri::toString)
         .collect(Collectors.toList());


### PR DESCRIPTION
TargetsLanguageOptionsResolver that I am using returns all outputs and inputs for given target. This includes source jars that are useless at runtime as well as hjars and ijars. For example this causes junit classes without bodies to appear on classpath and shadowing the actual implementation which fails tests at runtime. 
I proposed a simple workaround here, to just remove jars that *look like* not relevant for runtime. This fixed test running for me.
I feel like it is not *the solution*, I would like to know from bazel if a jar is relevant for runtime or not, but I don't know how to get  this.
I see that we might try the custom aspect approach from google's plugin: https://github.com/bazelbuild/intellij/blob/master/aspect/java_classpath.bzl but I hoped it should be easier than custom aspects during building...