### PR TITLE
Handle aspects when multiple projects are in workspace

### DIFF
--- a/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/BazelDataResolver.java
+++ b/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/BazelDataResolver.java
@@ -27,7 +27,8 @@ public class BazelDataResolver {
     String version = readOnlyBazelLine(BAZEL_VERSION_PARAMETER);
     Path workspacePath = Paths.get(execRoot);
     String workspaceLabel = workspacePath.toFile().getName();
-    return new BazelData(execRoot, workspaceRoot, binRoot, workspaceLabel, version);
+    Path bspProjectRoot = Paths.get("").toAbsolutePath().normalize();
+    return new BazelData(execRoot, workspaceRoot, binRoot, workspaceLabel, version, bspProjectRoot);
   }
 
   private String readOnlyBazelLine(String argument) {

--- a/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/data/BazelData.java
+++ b/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/data/BazelData.java
@@ -1,5 +1,7 @@
 package org.jetbrains.bsp.bazel.bazelrunner.data;
 
+import java.nio.file.Path;
+
 public class BazelData {
 
   private final String execRoot;
@@ -7,18 +9,21 @@ public class BazelData {
   private final String binRoot;
   private final String workspaceLabel;
   private final SemanticVersion version;
+  private final Path bspProjectRoot;
 
   public BazelData(
       String execRoot,
       String workspaceRoot,
       String binRoot,
       String workspaceLabel,
-      String version) {
+      String version,
+      Path bspProjectRoot) {
     this.execRoot = execRoot;
     this.workspaceRoot = workspaceRoot;
     this.binRoot = binRoot;
     this.workspaceLabel = workspaceLabel;
     this.version = SemanticVersion.fromReleaseData(version);
+    this.bspProjectRoot = bspProjectRoot;
   }
 
   public String getExecRoot() {
@@ -39,5 +44,9 @@ public class BazelData {
 
   public SemanticVersion getVersion() {
     return version;
+  }
+
+  public Path getBspProjectRoot() {
+    return bspProjectRoot;
   }
 }

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/Install.java
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/Install.java
@@ -81,7 +81,8 @@ public class Install {
         BspConnectionDetails details = createBspConnectionDetails(argv);
         writeConfigurationFiles(rootDir, details);
 
-        System.out.println("Bazel BSP server installed in '" + rootDir.toAbsolutePath() + "'.");
+        System.out.println(
+            "Bazel BSP server installed in '" + rootDir.toAbsolutePath().normalize() + "'.");
       }
     } catch (ParseException e) {
       writer.println(e.getMessage());

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/BUILD
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/BUILD
@@ -16,6 +16,7 @@ java_library(
         "//server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers",
         "//server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers",
         "//server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/services",
+        "//server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/utils",
         "@io_bazel//src/main/protobuf:build_java_proto",
         "@io_bazel//third_party/grpc:grpc-jar",
         "@maven//:ch_epfl_scala_bsp4j",

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/BazelBspServerBuildManager.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/BazelBspServerBuildManager.java
@@ -23,7 +23,7 @@ import org.jetbrains.bsp.bazel.server.bsp.managers.BazelCppTargetManager;
 
 public class BazelBspServerBuildManager {
 
-  public static final String BAZEL_PRINT_ASPECT = "@//.bazelbsp:aspects.bzl%print_aspect";
+  public static final String BAZEL_PRINT_ASPECT = "print_aspect";
 
   private final BazelBspServerRequestHelpers serverRequestHelpers;
   private final BazelBspQueryManager bazelBspQueryManager;
@@ -63,13 +63,8 @@ public class BazelBspServerBuildManager {
     // logging
     return bazelBspAspectsManager
         .fetchLinesFromAspect(target, BAZEL_PRINT_ASPECT)
-        .filter(
-            parts ->
-                parts.size() == 3
-                    && parts.get(0).equals(BazelBspAspectsManager.DEBUG_MESSAGE)
-                    && parts.get(1).contains(BazelBspAspectsManager.ASPECT_LOCATION)
-                    && parts.get(2).endsWith(".jar"))
-        .map(parts -> Constants.EXEC_ROOT_PREFIX + parts.get(2))
+        .filter(path -> path.endsWith(".jar"))
+        .map(path -> Constants.EXEC_ROOT_PREFIX + path)
         .collect(Collectors.toList());
   }
 

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspAspectsManager.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspAspectsManager.java
@@ -11,24 +11,28 @@ import org.jetbrains.bsp.bazel.bazelrunner.BazelRunner;
 import org.jetbrains.bsp.bazel.bazelrunner.params.BazelRunnerFlag;
 import org.jetbrains.bsp.bazel.commons.Uri;
 import org.jetbrains.bsp.bazel.server.bep.BepServer;
+import org.jetbrains.bsp.bazel.server.bsp.utils.InternalAspectsResolver;
 
 public class BazelBspAspectsManager {
 
   public static final String DEBUG_MESSAGE = "DEBUG:";
-  public static final String ASPECT_LOCATION = ".bazelbsp/aspects.bzl";
   private final BazelBspCompilationManager bazelBspCompilationManager;
   private final BazelRunner bazelRunner;
+  private final InternalAspectsResolver aspectsResolver;
   private BepServer bepServer;
 
   public BazelBspAspectsManager(
-      BazelBspCompilationManager bazelBspCompilationManager, BazelRunner bazelRunner) {
+      BazelBspCompilationManager bazelBspCompilationManager,
+      BazelRunner bazelRunner,
+      InternalAspectsResolver aspectResolver) {
     this.bazelBspCompilationManager = bazelBspCompilationManager;
     this.bazelRunner = bazelRunner;
+    this.aspectsResolver = aspectResolver;
   }
 
   public List<String> fetchPathsFromOutputGroup(
       List<BuildTargetIdentifier> targets, String aspect, String outputGroup) {
-    String aspectFlag = String.format("--aspects=%s", aspect);
+    String aspectFlag = String.format("--aspects=%s", aspectsResolver.resolveLabel(aspect));
     String outputGroupFlag = String.format("--output_groups=%s", outputGroup);
     bazelBspCompilationManager.buildTargetsWithBep(
         targets, ImmutableList.of(aspectFlag, outputGroupFlag));
@@ -40,18 +44,32 @@ public class BazelBspAspectsManager {
         .collect(Collectors.toList());
   }
 
-  public Stream<List<String>> fetchLinesFromAspect(String target, String aspect) {
-    List<String> lines =
+  public Stream<String> fetchLinesFromAspect(String target, String aspect) {
+    return fetchLinesFromAspect(target, aspect, false);
+  }
+
+  public Stream<String> fetchLinesFromAspect(String target, String aspect, boolean build) {
+    var builder =
         bazelRunner
             .commandBuilder()
             .build()
-            .withFlag(BazelRunnerFlag.NOBUILD)
-            .withFlag(BazelRunnerFlag.ASPECTS, aspect)
-            .withArgument(target)
-            .executeBazelCommand()
-            .getStderr();
+            .withFlag(BazelRunnerFlag.ASPECTS, aspectsResolver.resolveLabel(aspect))
+            .withArgument(target);
 
-    return lines.stream().map(line -> Splitter.on(" ").splitToList(line));
+    if (!build) {
+      builder.withFlag(BazelRunnerFlag.NOBUILD);
+    }
+
+    List<String> lines = builder.executeBazelCommand().getStderr();
+
+    return lines.stream()
+        .map(line -> Splitter.on(" ").splitToList(line))
+        .filter(
+            parts ->
+                parts.size() == 3
+                    && parts.get(0).equals(DEBUG_MESSAGE)
+                    && parts.get(1).contains(aspectsResolver.getAspectOutputIndicator()))
+        .map(parts -> parts.get(2));
   }
 
   public void setBepServer(BepServer bepServer) {

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspJvmTargetManager.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspJvmTargetManager.java
@@ -14,8 +14,7 @@ import org.jetbrains.bsp.bazel.commons.Uri;
 import org.jetbrains.bsp.bazel.server.bsp.resolvers.QueryResolver;
 
 public class BazelBspJvmTargetManager extends Lazy<String> {
-  public static final String FETCH_JAVA_VERSION_ASPECT =
-      "@//.bazelbsp:aspects.bzl%fetch_java_target_version";
+  public static final String FETCH_JAVA_VERSION_ASPECT = "fetch_java_target_version";
   public static final String BAZEL_JDK_CURRENT_JAVA_TOOLCHAIN =
       "@bazel_tools//tools/jdk:current_java_toolchain";
   private final BazelRunner bazelRunner;
@@ -82,13 +81,7 @@ public class BazelBspJvmTargetManager extends Lazy<String> {
   private Optional<String> getJavaVersion() {
     return bazelBspAspectsManager
         .fetchLinesFromAspect(BAZEL_JDK_CURRENT_JAVA_TOOLCHAIN, FETCH_JAVA_VERSION_ASPECT)
-        .filter(
-            parts ->
-                parts.size() == 3
-                    && parts.get(0).equals(BazelBspAspectsManager.DEBUG_MESSAGE)
-                    && parts.get(1).contains(BazelBspAspectsManager.ASPECT_LOCATION)
-                    && parts.get(2).chars().allMatch(Character::isDigit))
-        .map(parts -> parts.get(2))
+        .filter(line -> line.chars().allMatch(Character::isDigit))
         .findFirst();
   }
 

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspScalaTargetManager.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspScalaTargetManager.java
@@ -21,8 +21,7 @@ public class BazelBspScalaTargetManager extends Lazy<ScalaBuildTarget> {
       "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect";
   public static final String SCALA_COMPILER =
       "@io_bazel_rules_scala_scala_compiler//:io_bazel_rules_scala_scala_compiler";
-  public static final String SCALA_COMPILER_ASPECT =
-      "@//.bazelbsp:aspects.bzl%scala_compiler_classpath_aspect";
+  public static final String SCALA_COMPILER_ASPECT = "scala_compiler_classpath_aspect";
   public static final String SCALA_COMPILER_OUTPUT_GROUP = "scala_compiler_classpath_files";
   private final BazelBspAspectsManager bazelBspAspectsManager;
 

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelCppTargetManager.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelCppTargetManager.java
@@ -9,7 +9,7 @@ import org.jetbrains.bsp.bazel.commons.Lazy;
 
 public class BazelCppTargetManager extends Lazy<CppBuildTarget> {
   private static final String BAZEL_CPP_TOOLCHAIN = "@bazel_tools//tools/cpp:toolchain";
-  private static final String FETCH_CPP_ASPECT = "@//.bazelbsp:aspects.bzl%fetch_cpp_compiler";
+  private static final String FETCH_CPP_ASPECT = "fetch_cpp_compiler";
   private final BazelBspAspectsManager bazelBspAspectsManager;
 
   public BazelCppTargetManager(BazelBspAspectsManager bazelBspAspectsManager) {
@@ -20,12 +20,6 @@ public class BazelCppTargetManager extends Lazy<CppBuildTarget> {
     List<String> cppInfo =
         bazelBspAspectsManager
             .fetchLinesFromAspect(BAZEL_CPP_TOOLCHAIN, FETCH_CPP_ASPECT)
-            .filter(
-                parts ->
-                    parts.size() == 3
-                        && parts.get(0).equals(BazelBspAspectsManager.DEBUG_MESSAGE)
-                        && parts.get(1).contains(BazelBspAspectsManager.ASPECT_LOCATION))
-            .map(parts -> parts.get(2))
             .limit(2)
             .collect(Collectors.toList());
 

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/services/JvmBuildServerService.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/services/JvmBuildServerService.java
@@ -26,8 +26,7 @@ public class JvmBuildServerService {
   private static final Logger LOGGER = LogManager.getLogger(JvmBuildServerService.class);
   private static final ImmutableList<String> JVM_LANGUAGES_IDS =
       ImmutableList.of(Constants.JAVAC, Constants.KOTLINC, Constants.SCALAC);
-  public static final String JAVA_RUNTIME_CLASSPATH_ASPECT =
-      "@//.bazelbsp:aspects.bzl%java_runtime_classpath_aspect";
+  public static final String JAVA_RUNTIME_CLASSPATH_ASPECT = "java_runtime_classpath_aspect";
 
   private final TargetsLanguageOptionsResolver<JvmEnvironmentItem> targetsLanguageOptionsResolver;
   private final BazelBspAspectsManager bazelBspAspectsManager;

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/utils/InternalAspectsResolver.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/utils/InternalAspectsResolver.java
@@ -1,0 +1,21 @@
+package org.jetbrains.bsp.bazel.server.bsp.utils;
+
+import java.nio.file.Path;
+
+public class InternalAspectsResolver {
+
+  private final String prefix;
+
+  public InternalAspectsResolver(Path bspProjectRoot, Path workspaceRoot) {
+    var relative = workspaceRoot.relativize(bspProjectRoot).resolve(".bazelbsp").toString();
+    prefix = String.format("@//%s:aspects.bzl%%", relative);
+  }
+
+  public String getAspectOutputIndicator() {
+    return ".bazelbsp/aspects.bzl";
+  }
+
+  public String resolveLabel(String aspect) {
+    return prefix + aspect;
+  }
+}

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/bsp/utils/BUILD
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/bsp/utils/BUILD
@@ -27,3 +27,16 @@ java_test(
         "//server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/utils",
     ],
 )
+
+java_test(
+    name = "InternalAspectsResolverTest",
+    size = "small",
+    srcs = ["InternalAspectsResolverTest.java"],
+    runtime_deps = [
+        "@maven//:junit_junit",
+    ],
+    deps = [
+        "//commons",
+        "//server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/utils",
+    ],
+)

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/bsp/utils/InternalAspectsResolverTest.java
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/bsp/utils/InternalAspectsResolverTest.java
@@ -1,0 +1,55 @@
+package org.jetbrains.bsp.bazel.server.bsp.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(value = Parameterized.class)
+public class InternalAspectsResolverTest {
+
+  private Path workspaceRoot;
+  private Path bspRoot;
+  private String aspectName;
+  private String expectedAspectLabel;
+
+  public InternalAspectsResolverTest(
+      String workspaceRoot, String bspRoot, String aspectName, String expectedAspectLabel) {
+    this.workspaceRoot = Paths.get(workspaceRoot);
+    this.bspRoot = Paths.get(bspRoot);
+    this.aspectName = aspectName;
+    this.expectedAspectLabel = expectedAspectLabel;
+  }
+
+  @Test
+  public void shouldResolveLabels() {
+    String actual = new InternalAspectsResolver(bspRoot, workspaceRoot).resolveLabel(aspectName);
+    assertEquals(expectedAspectLabel, actual);
+  }
+
+  @Parameters
+  public static Collection<Object> data() {
+    return Arrays.asList(
+        (Object[])
+            new Object[][] {
+              {
+                "/Users/user/workspace/test-project",
+                "/Users/user/workspace/test-project",
+                "get_classpath",
+                "@//.bazelbsp:aspects.bzl%get_classpath"
+              },
+              {
+                "/Users/user/workspace/test-project",
+                "/Users/user/workspace/test-project/bsp-projects/test-project-bsp",
+                "get_classpath",
+                "@//bsp-projects/test-project-bsp/.bazelbsp:aspects.bzl%get_classpath"
+              },
+            });
+  }
+}


### PR DESCRIPTION
Path to aspects was absolute and hardcoded in multiple places as //.bazelbsp:aspects.bzl%ASPECT_NAME and this only works if workspace root == bsp root. I fixed this and made some refactoring.