### PR TITLE
Return only the relevant output jar rather than 5-6 jars 

### DIFF
--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers/TargetsLanguageOptionsResolver.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/resolvers/TargetsLanguageOptionsResolver.java
@@ -3,10 +3,11 @@ package org.jetbrains.bsp.bazel.server.bsp.resolvers;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.query2.proto.proto2api.Build;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.jetbrains.bsp.bazel.bazelrunner.BazelProcess;
 import org.jetbrains.bsp.bazel.bazelrunner.BazelRunner;
 import org.jetbrains.bsp.bazel.bazelrunner.data.BazelData;
@@ -52,11 +53,11 @@ public class TargetsLanguageOptionsResolver<T> {
         actionGraphResolver.getActionGraphParser(targets, languagesIds);
 
     return targets.stream()
-        .flatMap(target -> getResultItems(target, targets, actionGraphParser))
+        .flatMap(target -> getResultItems(target, targets, actionGraphParser).stream())
         .collect(Collectors.toList());
   }
 
-  private Stream<T> getResultItems(
+  private Optional<T> getResultItems(
       String target, List<String> allTargets, ActionGraphParser actionGraphParser) {
     Map<String, List<String>> targetsOptions = getTargetsOptions(allTargets);
 
@@ -87,7 +88,7 @@ public class TargetsLanguageOptionsResolver<T> {
     return BuildRuleAttributeExtractor.extract(rule, compilerOptionsName);
   }
 
-  private Stream<T> getResultItemForActionGraphParserOptionsTargetsOptionsAndTarget(
+  private Optional<T> getResultItemForActionGraphParserOptionsTargetsOptionsAndTarget(
       ActionGraphParser actionGraphParser,
       Map<String, List<String>> targetsOptions,
       String target) {
@@ -97,6 +98,7 @@ public class TargetsLanguageOptionsResolver<T> {
     List<String> inputs = actionGraphParser.getInputsAsUri(target, bazelData.getExecRoot());
 
     return actionGraphParser.getOutputs(target, ACTION_GRAPH_SUFFIXES).stream()
+        .max(Comparator.naturalOrder())
         .map(this::mapActionGraphOutputsToClassDirectory)
         .map(
             classDirectory ->


### PR DESCRIPTION
When bsp server asks for compile classpath and ouput (javac/scalac options), the server returns a list of identical responses except for class directory. There is one object per output. Bazel reports like 6 outputs jarname.jar jarname-src.jar jarname-native-headers.jar jarname-hjar.jar etc.
On the client side just one response per target is expected. The whole response is converted to map from target id to data which results basically in selecting random/last output from response. 
According to how bazel names these jars and sorting of strings works, my PR will select just the jarname.jar and return single response for a target.