### PR TITLE
[fix] error diagnostics with correct position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Improved heuristics for guessing source roots. It looks directory structures such as `src/java` or `main/java`. | [#126](https://github.com/JetBrains/bazel-bsp/pull/126)
 
 ### Fixes 🛠️
-- Now the project is built using bazel version `3.7.2`, as the rules currently used are no longer supported by bazel. | [141](https://github.com/JetBrains/bazel-bsp/pull/141)
+- Error diagnostics are now also sent for source files, including targets. | [#146](https://github.com/JetBrains/bazel-bsp/pull/146)
+- Now the project is built using bazel version `3.7.2`, as the rules currently used are no longer supported by bazel. | [#141](https://github.com/JetBrains/bazel-bsp/pull/141)
 
 
 ## [1.0.1] - 24.09.2021

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,10 @@ echo -e "Building done."
 
 echo -e "\nInstalling server at '$project_path' ..."
 cd "$project_path" || { echo "cd $project_path failed! EXITING"; exit 155; }
+
+rm -r .bsp/
+rm -r .bazelbsp/
+
 $bsp_path
 
 echo -e "\nDone! Enjoy Bazel BSP!"

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/BUILD
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/BUILD
@@ -3,7 +3,7 @@ load("@rules_java//java:defs.bzl", "java_library")
 java_library(
     name = "error",
     srcs = glob(["*.java"]),
-    visibility = ["//server/src/main/java/org/jetbrains/bsp/bazel/server/bep:__subpackages__"],
+    visibility = ["//server:__subpackages__"],
     deps = [
         "//commons",
         "@maven//:ch_epfl_scala_bsp4j",

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/FileDiagnostic.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/FileDiagnostic.java
@@ -26,17 +26,7 @@ public class FileDiagnostic {
     this.target = target;
   }
 
-  public static FileDiagnostic fromError(String error) {
-    LOGGER.info("Error: {}", error);
-
-    String erroredFile = ErrorFileParser.getFileWithError(error);
-    String fileInfo = ErrorFileParser.extractFileInfo(error);
-    String fileLocation = getFileLocation(erroredFile, fileInfo);
-
-    return createFileDiagnostic(error, fileLocation, new BuildTargetIdentifier(""));
-  }
-
-  public static Stream<FileDiagnostic> fromError2(String error) {
+  public static Stream<FileDiagnostic> fromError(String error) {
     LOGGER.info("Error: {}", error);
 
     var targetId = findTargetId(error);

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/FileDiagnostic.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/FileDiagnostic.java
@@ -1,9 +1,14 @@
 package org.jetbrains.bsp.bazel.server.bep.parsers.error;
 
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import ch.epfl.scala.bsp4j.Diagnostic;
 import ch.epfl.scala.bsp4j.DiagnosticSeverity;
 import ch.epfl.scala.bsp4j.Position;
 import ch.epfl.scala.bsp4j.Range;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -13,10 +18,12 @@ class FileDiagnostic {
 
   private final Diagnostic diagnostic;
   private final String fileLocation;
+  private final BuildTargetIdentifier target;
 
-  private FileDiagnostic(Diagnostic diagnostic, String fileLocation) {
+  FileDiagnostic(Diagnostic diagnostic, String fileLocation, BuildTargetIdentifier target) {
     this.diagnostic = diagnostic;
     this.fileLocation = fileLocation;
+    this.target = target;
   }
 
   public static FileDiagnostic fromError(String error) {
@@ -26,22 +33,82 @@ class FileDiagnostic {
     String fileInfo = ErrorFileParser.extractFileInfo(error);
     String fileLocation = getFileLocation(erroredFile, fileInfo);
 
-    return createFileDiagnostic(error, fileLocation);
+    return createFileDiagnostic(error, fileLocation, new BuildTargetIdentifier(""));
   }
 
-  private static FileDiagnostic createFileDiagnostic(String error, String fileLocation) {
-    Position position = ErrorPositionParser.getErrorPosition(error);
-    Range diagnosticRange = new Range(position, position);
-    Diagnostic diagnostic = new Diagnostic(diagnosticRange, error);
+  public static Stream<FileDiagnostic> fromError2(String error) {
+    LOGGER.info("Error: {}", error);
+
+    var targetId = findTargetId(error);
+
+    return Stream.concat(
+        Stream.of(createBUILDFileDiagnostic(error, targetId)),
+        createSourceFilesDiagnostics(error, targetId));
+  }
+
+  private static BuildTargetIdentifier findTargetId(String error) {
+    var matcher = Pattern.compile("//[^ :]*:?[^ :]+").matcher(error);
+
+    if (matcher.find()) {
+      var rawTargetId = matcher.group();
+      return new BuildTargetIdentifier(rawTargetId);
+    }
+
+    return new BuildTargetIdentifier("");
+  }
+
+  private static FileDiagnostic createBUILDFileDiagnostic(
+      String error, BuildTargetIdentifier targetId) {
+    var erroredFile = ErrorFileParser.getFileWithError(error);
+    var fileInfo = ErrorFileParser.extractFileInfo(error);
+    var fileLocation = getFileLocation(erroredFile, fileInfo);
+    var message = error.split("\n", 2)[0];
+
+    return createFileDiagnostic(message, fileLocation, targetId);
+  }
+
+  private static FileDiagnostic createFileDiagnostic(
+      String error, String fileLocation, BuildTargetIdentifier targetId) {
+    var position = ErrorPositionParser.getErrorPosition(error);
+    var diagnosticRange = new Range(position, position);
+    var diagnostic = new Diagnostic(diagnosticRange, error);
     diagnostic.setSeverity(DiagnosticSeverity.ERROR);
 
-    return new FileDiagnostic(diagnostic, fileLocation);
+    return new FileDiagnostic(diagnostic, fileLocation, targetId);
   }
 
   private static String getFileLocation(String erroredFile, String fileInfo) {
-    int fileLocationUrlEndIndex = fileInfo.indexOf(erroredFile) + erroredFile.length();
+    var fileLocationUrlEndIndex = fileInfo.indexOf(erroredFile) + erroredFile.length();
 
     return fileInfo.substring(0, fileLocationUrlEndIndex);
+  }
+
+  private static Stream<FileDiagnostic> createSourceFilesDiagnostics(
+      String error, BuildTargetIdentifier targetId) {
+    var pattern = Pattern.compile("\n((([^\\s\\/:]+\\/)*[^\\/:]+):(\\d+):[^\\^]*\\^)");
+    var matcher = pattern.matcher(error);
+
+    var result = new ArrayList<FileDiagnostic>();
+
+    while (matcher.find()) {
+      var message = matcher.group(1);
+      var filePath = matcher.group(2);
+      var errorLine = matcher.group(4);
+
+      result.add(createSourceFileDiagnostic(message, filePath, errorLine, targetId));
+    }
+
+    return result.stream();
+  }
+
+  private static FileDiagnostic createSourceFileDiagnostic(
+      String message, String filePath, String errorLine, BuildTargetIdentifier targetId) {
+    var position = new Position(Integer.parseInt(errorLine), 0);
+    var diagnosticRange = new Range(position, position);
+    var diagnostic = new Diagnostic(diagnosticRange, message);
+    diagnostic.setSeverity(DiagnosticSeverity.ERROR);
+
+    return new FileDiagnostic(diagnostic, filePath, targetId);
   }
 
   public Diagnostic getDiagnostic() {
@@ -50,5 +117,40 @@ class FileDiagnostic {
 
   public String getFileLocation() {
     return fileLocation;
+  }
+
+  public BuildTargetIdentifier getTarget() {
+    return target;
+  }
+
+  @Override
+  public String toString() {
+    return "FileDiagnostic{"
+        + "diagnostic="
+        + diagnostic
+        + ", fileLocation='"
+        + fileLocation
+        + '\''
+        + ", target="
+        + target
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    FileDiagnostic that = (FileDiagnostic) o;
+    // TODO normal .equals() fails don't know why...
+    return Objects.equals(diagnostic.getMessage(), that.diagnostic.getMessage())
+        && Objects.equals(diagnostic.getRange(), that.diagnostic.getRange())
+        && Objects.equals(diagnostic.getSeverity(), that.diagnostic.getSeverity())
+        && Objects.equals(fileLocation, that.fileLocation)
+        && Objects.equals(target, that.target);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(diagnostic, fileLocation, target);
   }
 }

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/FileDiagnostic.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/FileDiagnostic.java
@@ -12,7 +12,7 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-class FileDiagnostic {
+public class FileDiagnostic {
 
   private static final Logger LOGGER = LogManager.getLogger(FileDiagnostic.class);
 

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/StderrDiagnosticsParser.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/StderrDiagnosticsParser.java
@@ -1,6 +1,5 @@
 package org.jetbrains.bsp.bazel.server.bep.parsers.error;
 
-import ch.epfl.scala.bsp4j.Diagnostic;
 import com.google.common.base.Splitter;
 import java.util.List;
 import java.util.Map;
@@ -11,32 +10,15 @@ public final class StderrDiagnosticsParser {
 
   private static final String ERROR = "ERROR";
 
-  private static final String STDERR_DELIMITER = "\n";
-
-  public static Map<String, List<FileDiagnostic>> parse2(String stderr) {
-    return splitStderr2(stderr)
-        .filter(StderrDiagnosticsParser::isError)
-        .filter(StderrDiagnosticsParser::isBazelError)
-        .flatMap(FileDiagnostic::fromError2)
-        .collect(Collectors.groupingBy(FileDiagnostic::getFileLocation, Collectors.toList()));
-  }
-
-  public static Map<String, List<Diagnostic>> parse(String stderr) {
+  public static Map<String, List<FileDiagnostic>> parse(String stderr) {
     return splitStderr(stderr)
         .filter(StderrDiagnosticsParser::isError)
         .filter(StderrDiagnosticsParser::isBazelError)
-        .map(FileDiagnostic::fromError)
-        .collect(
-            Collectors.groupingBy(
-                FileDiagnostic::getFileLocation,
-                Collectors.mapping(FileDiagnostic::getDiagnostic, Collectors.toList())));
+        .flatMap(FileDiagnostic::fromError)
+        .collect(Collectors.groupingBy(FileDiagnostic::getFileLocation, Collectors.toList()));
   }
 
   private static Stream<String> splitStderr(String stderr) {
-    return Splitter.on(STDERR_DELIMITER).splitToList(stderr).stream();
-  }
-
-  private static Stream<String> splitStderr2(String stderr) {
     return Splitter.onPattern("(?=(ERROR:))").splitToList(stderr).stream();
   }
 

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/StderrDiagnosticsParser.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/StderrDiagnosticsParser.java
@@ -5,15 +5,20 @@ import com.google.common.base.Splitter;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public final class StderrDiagnosticsParser {
+
+  private static final Logger LOGGER = LogManager.getLogger(StderrDiagnosticsParser.class);
 
   private static final String ERROR = "ERROR";
 
   private static final String STDERR_DELIMITER = "\n";
 
   public static Map<String, List<Diagnostic>> parse(String stderr) {
-    return splitStderr(stderr).stream()
+    return splitStderr(stderr)
         .filter(StderrDiagnosticsParser::isError)
         .filter(StderrDiagnosticsParser::isBazelError)
         .map(FileDiagnostic::fromError)
@@ -23,8 +28,8 @@ public final class StderrDiagnosticsParser {
                 Collectors.mapping(FileDiagnostic::getDiagnostic, Collectors.toList())));
   }
 
-  private static List<String> splitStderr(String stderr) {
-    return Splitter.on(STDERR_DELIMITER).splitToList(stderr);
+  private static Stream<String> splitStderr(String stderr) {
+    return Splitter.on(STDERR_DELIMITER).splitToList(stderr).stream();
   }
 
   private static boolean isError(String stderrPart) {

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/StderrDiagnosticsParser.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/StderrDiagnosticsParser.java
@@ -6,16 +6,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public final class StderrDiagnosticsParser {
-
-  private static final Logger LOGGER = LogManager.getLogger(StderrDiagnosticsParser.class);
 
   private static final String ERROR = "ERROR";
 
   private static final String STDERR_DELIMITER = "\n";
+
+  public static Map<String, List<FileDiagnostic>> parse2(String stderr) {
+    return splitStderr2(stderr)
+        .filter(StderrDiagnosticsParser::isError)
+        .filter(StderrDiagnosticsParser::isBazelError)
+        .flatMap(FileDiagnostic::fromError2)
+        .collect(Collectors.groupingBy(FileDiagnostic::getFileLocation, Collectors.toList()));
+  }
 
   public static Map<String, List<Diagnostic>> parse(String stderr) {
     return splitStderr(stderr)
@@ -30,6 +34,10 @@ public final class StderrDiagnosticsParser {
 
   private static Stream<String> splitStderr(String stderr) {
     return Splitter.on(STDERR_DELIMITER).splitToList(stderr).stream();
+  }
+
+  private static Stream<String> splitStderr2(String stderr) {
+    return Splitter.onPattern("(?=(ERROR:))").splitToList(stderr).stream();
   }
 
   private static boolean isError(String stderrPart) {

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/BUILD
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/BUILD
@@ -1,0 +1,15 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+java_test(
+    name = "FileDiagnosticTest",
+    size = "small",
+    srcs = ["FileDiagnosticTest.java"],
+    runtime_deps = [
+        "@maven//:junit_junit",
+    ],
+    deps = [
+        "//server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error",
+        "@maven//:ch_epfl_scala_bsp4j",
+        "@maven//:com_google_guava_guava",
+    ],
+)

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/BUILD
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/BUILD
@@ -13,3 +13,17 @@ java_test(
         "@maven//:com_google_guava_guava",
     ],
 )
+
+java_test(
+    name = "StderrDiagnosticsParserTest",
+    size = "small",
+    srcs = ["StderrDiagnosticsParserTest.java"],
+    runtime_deps = [
+        "@maven//:junit_junit",
+    ],
+    deps = [
+        "//server/src/main/java/org/jetbrains/bsp/bazel/server/bep/parsers/error",
+        "@maven//:ch_epfl_scala_bsp4j",
+        "@maven//:com_google_guava_guava",
+    ],
+)

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/FileDiagnosticTest.java
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/FileDiagnosticTest.java
@@ -189,7 +189,7 @@ public class FileDiagnosticTest {
   @Test
   public void shouldReturnDiagnosticForBUILDFileAndSources() {
     // when
-    var diagnostics = FileDiagnostic.fromError2(error).collect(Collectors.toList());
+    var diagnostics = FileDiagnostic.fromError(error).collect(Collectors.toList());
 
     // then
     assertEquals(expectedDiagnostics, diagnostics);

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/FileDiagnosticTest.java
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/FileDiagnosticTest.java
@@ -1,0 +1,197 @@
+package org.jetbrains.bsp.bazel.server.bep.parsers.error;
+
+import static org.junit.Assert.assertEquals;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import ch.epfl.scala.bsp4j.Diagnostic;
+import ch.epfl.scala.bsp4j.DiagnosticSeverity;
+import ch.epfl.scala.bsp4j.Position;
+import ch.epfl.scala.bsp4j.Range;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(value = Parameterized.class)
+public class FileDiagnosticTest {
+
+  private final String error;
+  private final List<FileDiagnostic> expectedDiagnostics;
+
+  public FileDiagnosticTest(String error, List<FileDiagnostic> expectedDiagnostic) {
+    this.error = error;
+    this.expectedDiagnostics = expectedDiagnostic;
+  }
+
+  @Parameters(name = "{index}: FileDiagnostic.fromError({0}) should equals {1}")
+  public static List<Object[]> data() {
+    return List.of(
+        new Object[][] {
+          {
+            // given - error in BUILD file
+            "ERROR: /user/workspace/path/to/package/BUILD:12:37: in java_test rule"
+                + " //path/to/package:test: target '//path/to/another/package:lib' is not visible"
+                + " from target '//path/to/package:test'. Check the visibility declaration of the"
+                + " former target if you think the dependency is legitimate",
+            // then
+            List.of(
+                new FileDiagnostic(
+                    new Diagnostic(
+                        new Range(new Position(12, 37), new Position(12, 37)),
+                        "ERROR: /user/workspace/path/to/package/BUILD:12:37: in java_test rule"
+                            + " //path/to/package:test: target '//path/to/another/package:lib' is"
+                            + " not visible from target '//path/to/package:test'. Check the"
+                            + " visibility declaration of the former target if you think the"
+                            + " dependency is legitimate") {
+                      {
+                        setSeverity(DiagnosticSeverity.ERROR);
+                      }
+                    },
+                    "/user/workspace/path/to/package/BUILD",
+                    new BuildTargetIdentifier("//path/to/package:test")))
+          },
+          {
+            // given - error in one source file
+            "ERROR: /user/workspace/path/to/package/BUILD:12:37: scala //path/to/package:test"
+                + " failed: (Exit 1): scalac failed: error executing command"
+                + " bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/io_bazel_rules_scala/src/java/io/bazel/rulesscala/scalac/scalac"
+                + " @bazel-out/darwin-fastbuild/bin/path/to/package/test.jar-0.params\n"
+                + "path/to/package/Test.scala:3: error: type mismatch;\n"
+                + " found   : String(\"test\")\n"
+                + " required: Int\n"
+                + "  val foo: Int = \"test\"\n"
+                + "                 ^\n"
+                + "one error found\n"
+                + "Build failed\n"
+                + "java.lang.RuntimeException: Build failed\n"
+                + "\tat io.bazel.rulesscala.scalac.ScalacWorker.compileScalaSources(ScalacWorker.java:280)\n"
+                + "\tat io.bazel.rulesscala.scalac.ScalacWorker.work(ScalacWorker.java:63)\n"
+                + "\tat io.bazel.rulesscala.worker.Worker.persistentWorkerMain(Worker.java:92)\n"
+                + "\tat io.bazel.rulesscala.worker.Worker.workerMain(Worker.java:46)\n"
+                + "\tat io.bazel.rulesscala.scalac.ScalacWorker.main(ScalacWorker.java:26)\n"
+                + "Target //path/to/package:test failed to build\n"
+                + "Use --verbose_failures to see the command lines of failed build steps.\n"
+                + "INFO: Elapsed time: 0.220s, Critical Path: 0.09s\n"
+                + "INFO: 2 processes: 2 internal.\n"
+                + "FAILED: Build did NOT complete successfully",
+            // then
+            List.of(
+                new FileDiagnostic(
+                    new Diagnostic(
+                        new Range(new Position(12, 37), new Position(12, 37)),
+                        "ERROR: /user/workspace/path/to/package/BUILD:12:37: scala"
+                            + " //path/to/package:test failed: (Exit 1): scalac failed: error"
+                            + " executing command"
+                            + " bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/io_bazel_rules_scala/src/java/io/bazel/rulesscala/scalac/scalac"
+                            + " @bazel-out/darwin-fastbuild/bin/path/to/package/test.jar-0.params") {
+                      {
+                        setSeverity(DiagnosticSeverity.ERROR);
+                      }
+                    },
+                    "/user/workspace/path/to/package/BUILD",
+                    new BuildTargetIdentifier("//path/to/package:test")),
+                new FileDiagnostic(
+                    new Diagnostic(
+                        new Range(new Position(3, 0), new Position(3, 0)),
+                        "path/to/package/Test.scala:3: error: type mismatch;\n"
+                            + " found   : String(\"test\")\n"
+                            + " required: Int\n"
+                            + "  val foo: Int = \"test\"\n"
+                            + "                 ^") {
+                      {
+                        setSeverity(DiagnosticSeverity.ERROR);
+                      }
+                    },
+                    "path/to/package/Test.scala",
+                    new BuildTargetIdentifier("//path/to/package:test")))
+          },
+          {
+            // given - errors in two source files
+            "ERROR: /user/workspace/path/to/package/BUILD:12:37: scala //path/to/package:test"
+                + " failed (Exit 1): scalac failed: error executing command"
+                + " bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/io_bazel_rules_scala/src/java/io/bazel/rulesscala/scalac/scalac"
+                + " @bazel-out/darwin-fastbuild/bin/path/to/package/test.jar-0.params\n"
+                + "path/to/package/Test1.scala:21: error: type mismatch;\n"
+                + "found   : Int(42)\n"
+                + "required: String\n"
+                + "val x: String = 42\n"
+                + "^\n"
+                + "path/to/package/Test2.scala:37: error: type mismatch;\n"
+                + "found   : String(\"test\")\n"
+                + "required: Int\n"
+                + "val x: Int = \"test\"\n"
+                + "^\n"
+                + "2 errors\n"
+                + "Build failed\n"
+                + "java.lang.RuntimeException: Build failed\n"
+                + "at io.bazel.rulesscala.scalac.ScalacWorker.compileScalaSources(ScalacWorker.java:280)\n"
+                + "at io.bazel.rulesscala.scalac.ScalacWorker.work(ScalacWorker.java:63)\n"
+                + "at io.bazel.rulesscala.worker.Worker.persistentWorkerMain(Worker.java:92)\n"
+                + "at io.bazel.rulesscala.worker.Worker.workerMain(Worker.java:46)\n"
+                + "at io.bazel.rulesscala.scalac.ScalacWorker.main(ScalacWorker.java:26)\n"
+                + "Target //path/to/package:test failed to build\n"
+                + "Use --verbose_failures to see the command lines of failed build steps.\n"
+                + "INFO: Elapsed time: 0.216s, Critical Path: 0.12s\n"
+                + "INFO: 2 processes: 2 internal.\n"
+                + "FAILED: Build did NOT complete successfully\n"
+                + "FAILED: Build did NOT complete successfully\n"
+                + "FAILED: Build did NOT complete successfully",
+            // then
+            List.of(
+                new FileDiagnostic(
+                    new Diagnostic(
+                        new Range(new Position(12, 37), new Position(12, 37)),
+                        "ERROR: /user/workspace/path/to/package/BUILD:12:37: scala"
+                            + " //path/to/package:test failed (Exit 1): scalac failed: error"
+                            + " executing command"
+                            + " bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/io_bazel_rules_scala/src/java/io/bazel/rulesscala/scalac/scalac"
+                            + " @bazel-out/darwin-fastbuild/bin/path/to/package/test.jar-0.params") {
+                      {
+                        setSeverity(DiagnosticSeverity.ERROR);
+                      }
+                    },
+                    "/user/workspace/path/to/package/BUILD",
+                    new BuildTargetIdentifier("//path/to/package:test")),
+                new FileDiagnostic(
+                    new Diagnostic(
+                        new Range(new Position(21, 0), new Position(21, 0)),
+                        "path/to/package/Test1.scala:21: error: type mismatch;\n"
+                            + "found   : Int(42)\n"
+                            + "required: String\n"
+                            + "val x: String = 42\n"
+                            + "^") {
+                      {
+                        setSeverity(DiagnosticSeverity.ERROR);
+                      }
+                    },
+                    "path/to/package/Test1.scala",
+                    new BuildTargetIdentifier("//path/to/package:test")),
+                new FileDiagnostic(
+                    new Diagnostic(
+                        new Range(new Position(37, 0), new Position(37, 0)),
+                        "path/to/package/Test2.scala:37: error: type mismatch;\n"
+                            + "found   : String(\"test\")\n"
+                            + "required: Int\n"
+                            + "val x: Int = \"test\"\n"
+                            + "^") {
+                      {
+                        setSeverity(DiagnosticSeverity.ERROR);
+                      }
+                    },
+                    "path/to/package/Test2.scala",
+                    new BuildTargetIdentifier("//path/to/package:test")))
+          }
+        });
+  }
+
+  @Test
+  public void shouldReturnDiagnosticForBUILDFileAndSources() {
+    // when
+    var diagnostics = FileDiagnostic.fromError2(error).collect(Collectors.toList());
+
+    // then
+    assertEquals(expectedDiagnostics, diagnostics);
+  }
+}

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/StderrDiagnosticsParserTest.java
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/StderrDiagnosticsParserTest.java
@@ -314,7 +314,7 @@ public class StderrDiagnosticsParserTest {
   @Test
   public void shouldParseEntireEventStderr() {
     // when
-    var diagnostics = StderrDiagnosticsParser.parse2(error);
+    var diagnostics = StderrDiagnosticsParser.parse(error);
 
     // then
     assertEquals(expectedDiagnostics, diagnostics);

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/StderrDiagnosticsParserTest.java
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/bep/parsers/error/StderrDiagnosticsParserTest.java
@@ -1,0 +1,322 @@
+package org.jetbrains.bsp.bazel.server.bep.parsers.error;
+
+import static org.junit.Assert.assertEquals;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import ch.epfl.scala.bsp4j.Diagnostic;
+import ch.epfl.scala.bsp4j.DiagnosticSeverity;
+import ch.epfl.scala.bsp4j.Position;
+import ch.epfl.scala.bsp4j.Range;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(value = Parameterized.class)
+public class StderrDiagnosticsParserTest {
+
+  private final String error;
+  private final Map<String, List<FileDiagnostic>> expectedDiagnostics;
+
+  public StderrDiagnosticsParserTest(
+      String error, Map<String, List<FileDiagnostic>> expectedDiagnostics) {
+    this.error = error;
+    this.expectedDiagnostics = expectedDiagnostics;
+  }
+
+  @Parameters(name = "{index}: FileDiagnostic.fromError({0}) should equals {1}")
+  public static List<Object[]> data() {
+    return List.of(
+        new Object[][] {
+          {
+            // given - error in BUILD file
+            "Loading:\n"
+                + "Loading: 0 packages loaded\n"
+                + "Analyzing: target //path/to/package:test (0 packages loaded, 0 targets"
+                + " configured)\n"
+                + "INFO: Analyzed target //path/to/package:test (0 packages loaded, 0 targets"
+                + " configured).\n"
+                + "INFO: Found 1 target...\n"
+                + "[0 / 3] [Prepa] BazelWorkspaceStatusAction stable-status.txt\n"
+                + "ERROR: /user/workspace/path/to/package/BUILD:12:37: in java_test rule"
+                + " //path/to/package:test: target '//path/to/another/package:lib' is not visible"
+                + " from target '//path/to/package:test'. Check the visibility declaration of the"
+                + " former target if you think the dependency is legitimate",
+            // then
+            Map.of(
+                "/user/workspace/path/to/package/BUILD",
+                List.of(
+                    new FileDiagnostic(
+                        new Diagnostic(
+                            new Range(new Position(12, 37), new Position(12, 37)),
+                            "ERROR: /user/workspace/path/to/package/BUILD:12:37: in java_test rule"
+                                + " //path/to/package:test: target '//path/to/another/package:lib'"
+                                + " is not visible from target '//path/to/package:test'. Check the"
+                                + " visibility declaration of the former target if you think the"
+                                + " dependency is legitimate") {
+                          {
+                            setSeverity(DiagnosticSeverity.ERROR);
+                          }
+                        },
+                        "/user/workspace/path/to/package/BUILD",
+                        new BuildTargetIdentifier("//path/to/package:test"))))
+          },
+          {
+            // given - error in one source file
+            "Loading:\n"
+                + "Loading: 0 packages loaded\n"
+                + "Analyzing: target //path/to/package:test (0 packages loaded, 0 targets"
+                + " configured)\n"
+                + "INFO: Analyzed target //path/to/package:test (0 packages loaded, 0 targets"
+                + " configured).\n"
+                + "INFO: Found 1 target...\n"
+                + "[0 / 3] [Prepa] BazelWorkspaceStatusAction stable-status.txt\n"
+                + "ERROR: /user/workspace/path/to/package/BUILD:12:37: scala //path/to/package:test"
+                + " failed: (Exit 1): scalac failed: error executing command"
+                + " bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/io_bazel_rules_scala/src/java/io/bazel/rulesscala/scalac/scalac"
+                + " @bazel-out/darwin-fastbuild/bin/path/to/package/test.jar-0.params\n"
+                + "path/to/package/Test.scala:3: error: type mismatch;\n"
+                + " found   : String(\"test\")\n"
+                + " required: Int\n"
+                + "  val foo: Int = \"test\"\n"
+                + "                 ^\n"
+                + "one error found\n"
+                + "Build failed\n"
+                + "java.lang.RuntimeException: Build failed\n"
+                + "\tat io.bazel.rulesscala.scalac.ScalacWorker.compileScalaSources(ScalacWorker.java:280)\n"
+                + "\tat io.bazel.rulesscala.scalac.ScalacWorker.work(ScalacWorker.java:63)\n"
+                + "\tat io.bazel.rulesscala.worker.Worker.persistentWorkerMain(Worker.java:92)\n"
+                + "\tat io.bazel.rulesscala.worker.Worker.workerMain(Worker.java:46)\n"
+                + "\tat io.bazel.rulesscala.scalac.ScalacWorker.main(ScalacWorker.java:26)\n"
+                + "Target //path/to/package:test failed to build\n"
+                + "Use --verbose_failures to see the command lines of failed build steps.\n"
+                + "INFO: Elapsed time: 0.220s, Critical Path: 0.09s\n"
+                + "INFO: 2 processes: 2 internal.\n"
+                + "FAILED: Build did NOT complete successfully",
+            // then
+            Map.of(
+                "/user/workspace/path/to/package/BUILD",
+                List.of(
+                    new FileDiagnostic(
+                        new Diagnostic(
+                            new Range(new Position(12, 37), new Position(12, 37)),
+                            "ERROR: /user/workspace/path/to/package/BUILD:12:37: scala"
+                                + " //path/to/package:test failed: (Exit 1): scalac failed: error"
+                                + " executing command"
+                                + " bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/io_bazel_rules_scala/src/java/io/bazel/rulesscala/scalac/scalac"
+                                + " @bazel-out/darwin-fastbuild/bin/path/to/package/test.jar-0.params") {
+                          {
+                            setSeverity(DiagnosticSeverity.ERROR);
+                          }
+                        },
+                        "/user/workspace/path/to/package/BUILD",
+                        new BuildTargetIdentifier("//path/to/package:test"))),
+                "path/to/package/Test.scala",
+                List.of(
+                    new FileDiagnostic(
+                        new Diagnostic(
+                            new Range(new Position(3, 0), new Position(3, 0)),
+                            "path/to/package/Test.scala:3: error: type mismatch;\n"
+                                + " found   : String(\"test\")\n"
+                                + " required: Int\n"
+                                + "  val foo: Int = \"test\"\n"
+                                + "                 ^") {
+                          {
+                            setSeverity(DiagnosticSeverity.ERROR);
+                          }
+                        },
+                        "path/to/package/Test.scala",
+                        new BuildTargetIdentifier("//path/to/package:test"))))
+          },
+          {
+            // given - errors in two source files
+            "Loading:\n"
+                + "Loading: 0 packages loaded\n"
+                + "Analyzing: target //path/to/package:test (0 packages loaded, 0 targets"
+                + " configured)\n"
+                + "INFO: Analyzed target //path/to/package:test (0 packages loaded, 0 targets"
+                + " configured).\n"
+                + "INFO: Found 1 target...\n"
+                + "[0 / 3] [Prepa] BazelWorkspaceStatusAction stable-status.txt\n"
+                + "ERROR: /user/workspace/path/to/package/BUILD:12:37: scala //path/to/package:test"
+                + " failed (Exit 1): scalac failed: error executing command"
+                + " bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/io_bazel_rules_scala/src/java/io/bazel/rulesscala/scalac/scalac"
+                + " @bazel-out/darwin-fastbuild/bin/path/to/package/test.jar-0.params\n"
+                + "path/to/package/Test1.scala:21: error: type mismatch;\n"
+                + "found   : Int(42)\n"
+                + "required: String\n"
+                + "val x: String = 42\n"
+                + "^\n"
+                + "path/to/package/Test2.scala:37: error: type mismatch;\n"
+                + "found   : String(\"test\")\n"
+                + "required: Int\n"
+                + "val x: Int = \"test\"\n"
+                + "^\n"
+                + "2 errors\n"
+                + "Build failed\n"
+                + "java.lang.RuntimeException: Build failed\n"
+                + "at io.bazel.rulesscala.scalac.ScalacWorker.compileScalaSources(ScalacWorker.java:280)\n"
+                + "at io.bazel.rulesscala.scalac.ScalacWorker.work(ScalacWorker.java:63)\n"
+                + "at io.bazel.rulesscala.worker.Worker.persistentWorkerMain(Worker.java:92)\n"
+                + "at io.bazel.rulesscala.worker.Worker.workerMain(Worker.java:46)\n"
+                + "at io.bazel.rulesscala.scalac.ScalacWorker.main(ScalacWorker.java:26)\n"
+                + "Target //path/to/package:test failed to build\n"
+                + "Use --verbose_failures to see the command lines of failed build steps.\n"
+                + "INFO: Elapsed time: 0.216s, Critical Path: 0.12s\n"
+                + "INFO: 2 processes: 2 internal.\n"
+                + "FAILED: Build did NOT complete successfully\n"
+                + "FAILED: Build did NOT complete successfully\n"
+                + "FAILED: Build did NOT complete successfully",
+            // then
+            Map.of(
+                "/user/workspace/path/to/package/BUILD",
+                List.of(
+                    new FileDiagnostic(
+                        new Diagnostic(
+                            new Range(new Position(12, 37), new Position(12, 37)),
+                            "ERROR: /user/workspace/path/to/package/BUILD:12:37: scala"
+                                + " //path/to/package:test failed (Exit 1): scalac failed: error"
+                                + " executing command"
+                                + " bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/io_bazel_rules_scala/src/java/io/bazel/rulesscala/scalac/scalac"
+                                + " @bazel-out/darwin-fastbuild/bin/path/to/package/test.jar-0.params") {
+                          {
+                            setSeverity(DiagnosticSeverity.ERROR);
+                          }
+                        },
+                        "/user/workspace/path/to/package/BUILD",
+                        new BuildTargetIdentifier("//path/to/package:test"))),
+                "path/to/package/Test1.scala",
+                List.of(
+                    new FileDiagnostic(
+                        new Diagnostic(
+                            new Range(new Position(21, 0), new Position(21, 0)),
+                            "path/to/package/Test1.scala:21: error: type mismatch;\n"
+                                + "found   : Int(42)\n"
+                                + "required: String\n"
+                                + "val x: String = 42\n"
+                                + "^") {
+                          {
+                            setSeverity(DiagnosticSeverity.ERROR);
+                          }
+                        },
+                        "path/to/package/Test1.scala",
+                        new BuildTargetIdentifier("//path/to/package:test"))),
+                "path/to/package/Test2.scala",
+                List.of(
+                    new FileDiagnostic(
+                        new Diagnostic(
+                            new Range(new Position(37, 0), new Position(37, 0)),
+                            "path/to/package/Test2.scala:37: error: type mismatch;\n"
+                                + "found   : String(\"test\")\n"
+                                + "required: Int\n"
+                                + "val x: Int = \"test\"\n"
+                                + "^") {
+                          {
+                            setSeverity(DiagnosticSeverity.ERROR);
+                          }
+                        },
+                        "path/to/package/Test2.scala",
+                        new BuildTargetIdentifier("//path/to/package:test"))))
+          },
+          {
+            // given - errors in one source file
+            "Loading:\n"
+                + "Loading: 0 packages loaded\n"
+                + "Analyzing: target //path/to/package:test (0 packages loaded, 0 targets"
+                + " configured)\n"
+                + "INFO: Analyzed target //path/to/package:test (0 packages loaded, 0 targets"
+                + " configured).\n"
+                + "INFO: Found 1 target...\n"
+                + "[0 / 3] [Prepa] BazelWorkspaceStatusAction stable-status.txt\n"
+                + "ERROR: /user/workspace/path/to/package/BUILD:12:37: scala //path/to/package:test"
+                + " failed (Exit 1): scalac failed: error executing command"
+                + " bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/io_bazel_rules_scala/src/java/io/bazel/rulesscala/scalac/scalac"
+                + " @bazel-out/darwin-fastbuild/bin/path/to/package/test.jar-0.params\n"
+                + "path/to/package/Test.scala:21: error: type mismatch;\n"
+                + "found   : Int(42)\n"
+                + "required: String\n"
+                + "val x: String = 42\n"
+                + "^\n"
+                + "path/to/package/Test.scala:37: error: type mismatch;\n"
+                + "found   : String(\"test\")\n"
+                + "required: Int\n"
+                + "val x: Int = \"test\"\n"
+                + "^\n"
+                + "2 errors\n"
+                + "Build failed\n"
+                + "java.lang.RuntimeException: Build failed\n"
+                + "at io.bazel.rulesscala.scalac.ScalacWorker.compileScalaSources(ScalacWorker.java:280)\n"
+                + "at io.bazel.rulesscala.scalac.ScalacWorker.work(ScalacWorker.java:63)\n"
+                + "at io.bazel.rulesscala.worker.Worker.persistentWorkerMain(Worker.java:92)\n"
+                + "at io.bazel.rulesscala.worker.Worker.workerMain(Worker.java:46)\n"
+                + "at io.bazel.rulesscala.scalac.ScalacWorker.main(ScalacWorker.java:26)\n"
+                + "Target //path/to/package:test failed to build\n"
+                + "Use --verbose_failures to see the command lines of failed build steps.\n"
+                + "INFO: Elapsed time: 0.216s, Critical Path: 0.12s\n"
+                + "INFO: 2 processes: 2 internal.\n"
+                + "FAILED: Build did NOT complete successfully\n"
+                + "FAILED: Build did NOT complete successfully\n"
+                + "FAILED: Build did NOT complete successfully",
+            // then
+            Map.of(
+                "/user/workspace/path/to/package/BUILD",
+                List.of(
+                    new FileDiagnostic(
+                        new Diagnostic(
+                            new Range(new Position(12, 37), new Position(12, 37)),
+                            "ERROR: /user/workspace/path/to/package/BUILD:12:37: scala"
+                                + " //path/to/package:test failed (Exit 1): scalac failed: error"
+                                + " executing command"
+                                + " bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/io_bazel_rules_scala/src/java/io/bazel/rulesscala/scalac/scalac"
+                                + " @bazel-out/darwin-fastbuild/bin/path/to/package/test.jar-0.params") {
+                          {
+                            setSeverity(DiagnosticSeverity.ERROR);
+                          }
+                        },
+                        "/user/workspace/path/to/package/BUILD",
+                        new BuildTargetIdentifier("//path/to/package:test"))),
+                "path/to/package/Test.scala",
+                List.of(
+                    new FileDiagnostic(
+                        new Diagnostic(
+                            new Range(new Position(21, 0), new Position(21, 0)),
+                            "path/to/package/Test.scala:21: error: type mismatch;\n"
+                                + "found   : Int(42)\n"
+                                + "required: String\n"
+                                + "val x: String = 42\n"
+                                + "^") {
+                          {
+                            setSeverity(DiagnosticSeverity.ERROR);
+                          }
+                        },
+                        "path/to/package/Test.scala",
+                        new BuildTargetIdentifier("//path/to/package:test")),
+                    new FileDiagnostic(
+                        new Diagnostic(
+                            new Range(new Position(37, 0), new Position(37, 0)),
+                            "path/to/package/Test.scala:37: error: type mismatch;\n"
+                                + "found   : String(\"test\")\n"
+                                + "required: Int\n"
+                                + "val x: Int = \"test\"\n"
+                                + "^") {
+                          {
+                            setSeverity(DiagnosticSeverity.ERROR);
+                          }
+                        },
+                        "path/to/package/Test.scala",
+                        new BuildTargetIdentifier("//path/to/package:test"))))
+          }
+        });
+  }
+
+  @Test
+  public void shouldParseEntireEventStderr() {
+    // when
+    var diagnostics = StderrDiagnosticsParser.parse2(error);
+
+    // then
+    assertEquals(expectedDiagnostics, diagnostics);
+  }
+}


### PR DESCRIPTION
This is not the best possible solution, entire event handling should be done better, but for now it should be sufficient.

---
Fixes https://github.com/JetBrains/bazel-bsp/issues/67 
Fixes https://github.com/JetBrains/bazel-bsp/issues/111
Fixes https://github.com/JetBrains/bazel-bsp/issues/145

---
testing:
```
bazel test //server/src/test/java/org/jetbrains/bsp/bazel/server/bep/parsers/error:FileDiagnosticTest
bazel test //server/src/test/java/org/jetbrains/bsp/bazel/server/bep/parsers/error:StderrDiagnosticsParserTest
```
and manually on some sample repo like [this](https://github.com/kpodsiad/bazel-scala)