### PR TITLE
Set the Scala version and build classpath for Scala targets using the list of runfiles retrieved from Bazel.

### DIFF
--- a/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/data/BazelProcessResult.java
+++ b/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/data/BazelProcessResult.java
@@ -30,6 +30,10 @@ public class BazelProcessResult {
     return stdout.get();
   }
 
+  public List<String> getStderr() {
+    return stderr.get();
+  }
+
   public String getJoinedStderr() {
     List<String> lines = stderr.get();
     return String.join(LINES_DELIMITER, lines);

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/aspects.bzl
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/aspects.bzl
@@ -46,6 +46,19 @@ java_runtime_classpath_aspect = aspect(
     implementation = _java_runtime_classpath_impl,
 )
 
+def _print_runfiles(target, ctx):
+    print("Runtime files for %s %s" % (ctx.rule.kind, str(target.label)))
+    runfiles = target.default_runfiles.files.to_list()
+    for runfile in runfiles:
+        if not runfile.owner == target.label:
+            print("[file_owner]%s" % runfile.owner)
+            print("[file_path]%s" % runfile.path)
+    return []
+
+print_runfiles = aspect(
+    implementation = _print_runfiles,
+)
+
 def _fetch_cpp_compiler(target, ctx):
     if cc_common.CcToolchainInfo in target:
         toolchain_info = target[cc_common.CcToolchainInfo]

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/aspects.bzl
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/aspects.bzl
@@ -50,9 +50,10 @@ def _print_runfiles(target, ctx):
     print("Runtime files for %s %s" % (ctx.rule.kind, str(target.label)))
     runfiles = target.default_runfiles.files.to_list()
     for runfile in runfiles:
-        if not runfile.owner == target.label:
-            print("[file_owner]%s" % runfile.owner)
-            print("[file_path]%s" % runfile.path)
+        if "scala" in runfile.path:
+            if not runfile.owner == target.label:
+                print("[file_owner]%s" % runfile.owner)
+                print("[file_path]%s" % runfile.path)
     return []
 
 print_runfiles = aspect(

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/BazelBspServerBuildManager.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/BazelBspServerBuildManager.java
@@ -88,8 +88,6 @@ public class BazelBspServerBuildManager {
   }
 
   public List<Lazy<?>> getLazyVals() {
-    return ImmutableList.of(
-        bazelBspTargetManager.getBazelBspJvmTargetManager(),
-        bazelBspTargetManager.getBazelBspScalaTargetManager());
+    return ImmutableList.of(bazelBspTargetManager.getBazelBspJvmTargetManager());
   }
 }

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspAspectsManager.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspAspectsManager.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jetbrains.bsp.bazel.bazelrunner.BazelRunner;
+import org.jetbrains.bsp.bazel.bazelrunner.data.BazelProcessResult;
 import org.jetbrains.bsp.bazel.bazelrunner.params.BazelRunnerFlag;
 import org.jetbrains.bsp.bazel.commons.Uri;
 import org.jetbrains.bsp.bazel.server.bep.BepServer;
@@ -42,6 +43,20 @@ public class BazelBspAspectsManager {
         .stream()
         .map(Uri::toString)
         .collect(Collectors.toList());
+  }
+
+  public BazelProcessResult fetchResultFromAspect(String target, String aspect) {
+    BazelProcessResult result =
+        bazelRunner
+            .commandBuilder()
+            .build()
+            .withFlag(BazelRunnerFlag.NOBUILD)
+            .withFlag(BazelRunnerFlag.ASPECTS, aspectsResolver.resolveLabel(aspect))
+            .withArgument(target)
+            .executeBazelCommand()
+            .waitAndGetResult();
+
+    return result;
   }
 
   public Stream<String> fetchLinesFromAspect(String target, String aspect) {

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspScalaTargetManager.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspScalaTargetManager.java
@@ -45,6 +45,7 @@ public class BazelBspScalaTargetManager {
     List<String> classpath =
         runfilePaths.stream()
             .map(line -> line.replaceFirst("^.*\\[file_path\\]", ""))
+            .filter(x -> x.matches(".*scala-(?:library|compiler|reflect).*"))
             .map(path -> Uri.fromWorkspacePath(path, bazelData.getWorkspaceRoot()))
             .map(Uri::toString)
             .collect(Collectors.toList());

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspTargetManager.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspTargetManager.java
@@ -22,20 +22,21 @@ public class BazelBspTargetManager {
       BazelData bazelData,
       BazelBspAspectsManager bazelBspAspectsManager,
       BazelCppTargetManager bazelCppTargetManager) {
-    this.bazelBspScalaTargetManager = new BazelBspScalaTargetManager(bazelBspAspectsManager);
+    this.bazelBspScalaTargetManager =
+        new BazelBspScalaTargetManager(bazelBspAspectsManager, bazelData);
     this.bazelCppTargetManager = bazelCppTargetManager;
     this.bazelBspJvmTargetManager =
         new BazelBspJvmTargetManager(bazelRunner, bazelData, bazelBspAspectsManager);
   }
 
   private Optional<ScalaBuildTarget> getScalaBuildTarget(Build.Rule rule) {
-    return bazelBspScalaTargetManager
-        .getValue()
-        .map(
-            target -> {
-              target.setJvmBuildTarget(bazelBspJvmTargetManager.getJVMBuildTarget(rule));
-              return target;
-            });
+    Optional<ScalaBuildTarget> result =
+        bazelBspScalaTargetManager.getScalaBuildTarget(rule.getName());
+    return result.map(
+        target -> {
+          target.setJvmBuildTarget(bazelBspJvmTargetManager.getJVMBuildTarget(rule));
+          return target;
+        });
   }
 
   public void fillTargetData(
@@ -62,10 +63,6 @@ public class BazelBspTargetManager {
                 target.setData(buildTarget);
               });
     }
-  }
-
-  public BazelBspScalaTargetManager getBazelBspScalaTargetManager() {
-    return bazelBspScalaTargetManager;
   }
 
   public BazelBspJvmTargetManager getBazelBspJvmTargetManager() {


### PR DESCRIPTION
This seems to fix #127.

The [runfiles](https://docs.bazel.build/versions/main/skylark/rules.html#runfiles) are actually the files that a target needs at run time, so  using them to populate the compile classpath might yield some redundant items. However, this seems to work reasonably well and doesn't crash like the previous solution.