### PR TITLE
[change] improve source dependencies performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 - Now the project is using the latest bazel version - `5.0.0`.
   Installer skips bazelisk cache binaries during bazel binary discovery mechanism.
   | [#160](https://github.com/JetBrains/bazel-bsp/pull/160)
+- Rewrite of all endpoints to rely on single bazel aspect to extract all necessary data.
+  It improves performance and correctness as wel as extensibility of the server.
+  With this change also c++ support is temporarily dropped.
+  | [#147](https://github.com/JetBrains/bazel-bsp/pull/147)
 
 ## [1.1.1] - 16.02.2022
 

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/java/JavaLanguagePlugin.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/java/JavaLanguagePlugin.java
@@ -13,7 +13,6 @@ import io.vavr.collection.Seq;
 import io.vavr.collection.Set;
 import io.vavr.control.Option;
 import java.net.URI;
-import java.util.stream.Stream;
 import org.jetbrains.bsp.bazel.bazelrunner.data.BazelData;
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.JavaTargetInfo;
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.TargetInfo;
@@ -87,14 +86,8 @@ public class JavaLanguagePlugin extends LanguagePlugin<JavaModule> {
     if (!targetInfo.hasJavaTargetInfo()) {
       return HashSet.empty();
     }
-
-    var allSourceJars =
-        Stream.concat(
-                targetInfo.getJavaTargetInfo().getJarsList().stream(),
-                targetInfo.getJavaTargetInfo().getGeneratedJarsList().stream())
-            .flatMap(outputs -> outputs.getSourceJarsList().stream());
-
-    return HashSet.ofAll(allSourceJars).map(bazelPathsResolver::resolveUri);
+    var sourceJars = targetInfo.getJavaTargetInfo().getSourceClasspathList();
+    return HashSet.ofAll(sourceJars).map(bazelPathsResolver::resolveUri);
   }
 
   @Override


### PR DESCRIPTION
Traversing dependency graph the way it was implemented (very naively) is painfully slow, which can be noticed on bigger projects. It would be nice to have a graph built once and just take all direct deps from it based on condition to not duplicate them.
As a fairly reasonable workaround, I just take transitive source deps directly from bazel where they are already computed anyway. BSP client will deduplicate and group it anyway.