### PR TITLE
[change] forward the no-ide tag from bazel to bsp client

### DIFF
--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/TargetKindResolver.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/TargetKindResolver.java
@@ -20,6 +20,9 @@ public class TargetKindResolver {
             .map(Map.Entry::getValue)
             .findFirst()
             .orElse(Tag.NO_IDE);
+    if (targetInfo.getTagsList().contains("no-ide")) {
+      return HashSet.of(tag, Tag.NO_IDE);
+    }
     return HashSet.of(tag);
   }
 }


### PR DESCRIPTION
Users can manually mark the target as excluded from IDE by using tags. BSP also supports NO_IDE tag, we just need to make sure it is forwarded.