### PR TITLE
[change] do not forward duplicate lines to bsp-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 ### Changes 🔄
 
+- Duplicate bazel output lines are not shown in bsp-client.
+  | [#209](https://github.com/JetBrains/bazel-bsp/pull/209)
 - Project uses bazel `5.1.0`.
   | [#208](https://github.com/JetBrains/bazel-bsp/pull/208)
 - JUnit5!

--- a/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/outputs/AsyncOutputProcessor.java
+++ b/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/outputs/AsyncOutputProcessor.java
@@ -26,9 +26,12 @@ public class AsyncOutputProcessor {
     Runnable runnable =
         () -> {
           try (var reader = new BufferedReader(new InputStreamReader(inputStream))) {
+            String prevLine = null;
             while (!Thread.currentThread().isInterrupted()) {
               var line = reader.readLine();
               if (line == null) return;
+              if (line.equals(prevLine)) continue;
+              prevLine = line;
               Arrays.stream(handlers).forEach(h -> h.onNextLine(line));
             }
           } catch (IOException e) {


### PR DESCRIPTION
bazel outputs identical lines, one after another. This is cosmetic change, there is no point to show them, they only make everything less clear.