### PR TITLE
Stream bazel query output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 - Project uses bazel `5.1.0`.
   | [#208](https://github.com/JetBrains/bazel-bsp/pull/208)
+- Parse bazel query output from stream rather than from all bytes.
+  | [#210](https://github.com/JetBrains/bazel-bsp/pull/210)
 - JUnit5!
   | [#206](https://github.com/JetBrains/bazel-bsp/pull/206)
 - Do not throw on aborted event from BEP. Show warning instead.

--- a/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/BazelProcess.java
+++ b/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/BazelProcess.java
@@ -1,7 +1,8 @@
 package org.jetbrains.bsp.bazel.bazelrunner;
 
-import java.io.IOException;
+import java.io.InputStream;
 import java.time.Duration;
+import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.bsp.bazel.bazelrunner.outputs.AsyncOutputProcessor;
@@ -41,20 +42,20 @@ public class BazelProcess {
     }
   }
 
-  public byte[] waitAndGetBinaryResult() {
+  public <T> T processBinaryOutput(Function<InputStream, T> func) {
     try {
       var stopwatch = Stopwatch.start();
-      byte[] bytes = process.getInputStream().readAllBytes();
+      var result = func.apply(process.getInputStream());
       var exitCode = process.waitFor();
       var duration = stopwatch.stop();
       logCompletion(exitCode, duration);
-      return bytes;
-    } catch (IOException | InterruptedException e) {
+      return result;
+    } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }
   }
 
   private void logCompletion(int exitCode, Duration duration) {
-    logger.message("Command completed in %s (exit code: %d)", Format.duration(duration), exitCode);
+    logger.message("Command completed in %s (exit code %d)", Format.duration(duration), exitCode);
   }
 }

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspCompilationManager.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspCompilationManager.java
@@ -1,9 +1,10 @@
 package org.jetbrains.bsp.bazel.server.bsp.managers;
 
+import static io.vavr.API.unchecked;
+
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import com.google.devtools.build.lib.query2.proto.proto2api.Build;
 import io.vavr.collection.List;
-import java.io.IOException;
 import java.util.Map;
 import org.jetbrains.bsp.bazel.bazelrunner.BazelInfo;
 import org.jetbrains.bsp.bazel.bazelrunner.BazelProcess;
@@ -94,15 +95,11 @@ public class BazelBspCompilationManager {
   }
 
   private Build.QueryResult getQueryResultForProcess(BazelProcess process) {
-    try {
-      return Build.QueryResult.parseFrom(process.waitAndGetBinaryResult());
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    return process.processBinaryOutput(unchecked(stream -> Build.QueryResult.parseFrom(stream)));
   }
 
   private String convertOutputToPath(String output, String prefix) {
-    String pathToFile = output.replaceAll("(//|:)", "/");
+    var pathToFile = output.replaceAll("(//|:)", "/");
     return prefix + pathToFile;
   }
 }


### PR DESCRIPTION
Originally I was reading all bytes to memory to be able to return it and report how long the command took. After I got some OOM on reading this data for large project, I figured it is better to parse it from stream. I can achieve both goals by passing a lambda that maps the stream and then return mapped result.