### PR TITLE
[fix] project view path is mapped to the absolute path in the installer | #BAZEL-20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Fixes 🛠️
 
+- Project view path is mapped to the absolute path in the installer.
+  | [#213](https://github.com/JetBrains/bazel-bsp/pull/213)
 - Kotlin targets don't break import.
   | [#211](https://github.com/JetBrains/bazel-bsp/pull/211)
 - Now sources of thrift dependencies are included as dependencies.

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.java
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.java
@@ -85,6 +85,6 @@ public class CliOptionsProvider {
   private io.vavr.control.Option<Path> getProjectViewPath(CommandLine cmd) {
     return io.vavr.control.Option.when(
         cmd.hasOption(PROJECT_VIEW_FILE_PATH_SHORT_OPT),
-        () -> Paths.get(cmd.getOptionValue(PROJECT_VIEW_FILE_PATH_SHORT_OPT)));
+        () -> Paths.get(cmd.getOptionValue(PROJECT_VIEW_FILE_PATH_SHORT_OPT)).toAbsolutePath());
   }
 }

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.java
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.java
@@ -79,12 +79,23 @@ public class CliOptionsProvider {
   private Path getWorkspaceRootDir(CommandLine cmd) {
     return cmd.hasOption(DIRECTORY_SHORT_OPT)
         ? Paths.get(cmd.getOptionValue(DIRECTORY_SHORT_OPT))
-        : Paths.get("");
+        : getCurrentDirectory();
   }
 
   private io.vavr.control.Option<Path> getProjectViewPath(CommandLine cmd) {
     return io.vavr.control.Option.when(
         cmd.hasOption(PROJECT_VIEW_FILE_PATH_SHORT_OPT),
-        () -> Paths.get(cmd.getOptionValue(PROJECT_VIEW_FILE_PATH_SHORT_OPT)).toAbsolutePath());
+        () -> calculateAbsoluteProjectViewPath(cmd));
+  }
+
+  private Path calculateAbsoluteProjectViewPath(CommandLine cmd) {
+    var currentDir = getCurrentDirectory();
+    var projectViewPath = Paths.get(cmd.getOptionValue(PROJECT_VIEW_FILE_PATH_SHORT_OPT));
+
+    return currentDir.resolve(projectViewPath).normalize();
+  }
+
+  private Path getCurrentDirectory() {
+    return Paths.get("").toAbsolutePath();
   }
 }


### PR DESCRIPTION
Now installer maps the path to the project view file into absolute path - it means that this path is resolved using PWD of the installer, now PWD of the server

---

[#BAZEL-20](https://youtrack.jetbrains.com/issue/BAZEL-20)

---

testing: manual : (