### PR TITLE
[change] diagnostic message doesn't contain path to file anymore & column number is now inferred from the message | #BAZEL-51 fixed

### DIFF
--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/diagnostics/CompilerDiagnosticParser.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/diagnostics/CompilerDiagnosticParser.kt
@@ -23,11 +23,16 @@ object CompilerDiagnosticParser : Parser {
           ?.let { match ->
             val path = match.groupValues[1]
             val line = match.groupValues[2].toInt()
-            val column = match.groupValues[3].toIntOrNull() ?: 1
+            val column = match.groupValues[3].toIntOrNull() ?: tryFindColumnNumber(output) ?: 1
             val level = if (match.groupValues[4] == "warning") Level.Warning else Level.Error
             val message = constructMessage(match.groupValues[5], output)
             Diagnostic(Position(line, column), message, level, path, targetLabel)
           }
+
+  private fun tryFindColumnNumber(output: Output): Int? {
+    val line = output.peek(limit = 20).find { IssuePositionMarker.matches(it) }
+    return line?.indexOf("^")?. let { it + 1 }
+  }
 
   private fun constructMessage(header: String, output: Output): String {
     val lines = mutableListOf<String>()

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/diagnostics/CompilerDiagnosticParser.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/diagnostics/CompilerDiagnosticParser.kt
@@ -14,7 +14,7 @@ object CompilerDiagnosticParser : Parser {
       (?::(\d+))?      # optional column number (3)
       :\               # ": " separator
       ([a-zA-Z\ ]+):\  # level (4)
-      .*               # actual error message
+      (.*)             # actual error message (5)
       $                # end of line
       """.toRegex(RegexOption.COMMENTS)
 
@@ -25,7 +25,7 @@ object CompilerDiagnosticParser : Parser {
             val line = match.groupValues[2].toInt()
             val column = match.groupValues[3].toIntOrNull() ?: 1
             val level = if (match.groupValues[4] == "warning") Level.Warning else Level.Error
-            val message = constructMessage(match.value, output)
+            val message = constructMessage(match.groupValues[5], output)
             Diagnostic(Position(line, column), message, level, path, targetLabel)
           }
 

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsServiceTest.kt
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsServiceTest.kt
@@ -2,7 +2,6 @@ package org.jetbrains.bsp.bazel.server.diagnostics
 
 import ch.epfl.scala.bsp4j.*
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
-import org.assertj.core.api.Assertions
 import org.jetbrains.bsp.bazel.bazelrunner.BasicBazelInfo
 import org.junit.jupiter.api.Test
 import java.nio.file.Paths
@@ -79,14 +78,13 @@ class DiagnosticsServiceTest {
             BuildTargetIdentifier("//path/to/package:test"),
             ErrorDiagnostic(
                 Position(3, 1),
-                """path/to/package/Test.scala:3: error: type mismatch;
+                """type mismatch;
                   | found   : String("test")
                   | required: Int
                   |  val foo: Int = "test"
                   |                 ^""".trimMargin())))
-    Assertions.assertThat(diagnostics).containsExactlyInAnyOrderElementsOf(expected)
+    diagnostics shouldContainExactlyInAnyOrder expected
   }
-
 
   @Test
   fun `should extract diagnostics for error in 2 source files`() {
@@ -135,7 +133,7 @@ class DiagnosticsServiceTest {
             BuildTargetIdentifier("//path/to/package:test"),
             ErrorDiagnostic(
                 Position(21, 1),
-                """path/to/package/Test1.scala:21: error: type mismatch;
+                """type mismatch;
                   |  found   : Int(42)
                   |  required: String
                   |    val x: String = 42
@@ -146,13 +144,13 @@ class DiagnosticsServiceTest {
             BuildTargetIdentifier("//path/to/package:test"),
             ErrorDiagnostic(
                 Position(37, 1),
-                """path/to/package/Test2.scala:37: error: type mismatch;
+                """type mismatch;
                   |  found   : String("test")
                   |  required: Int
                   |    val x: Int = "test"
                   |                 ^""".trimMargin())
         ))
-    Assertions.assertThat(diagnostics).containsExactlyInAnyOrderElementsOf(expected)
+    diagnostics shouldContainExactlyInAnyOrder expected
   }
 
   @Test
@@ -201,20 +199,20 @@ class DiagnosticsServiceTest {
             BuildTargetIdentifier("//path/to/package:test"),
             ErrorDiagnostic(
                 Position(21, 1),
-                """path/to/package/Test.scala:21: error: type mismatch;
+                """type mismatch;
                   |  found   : Int(42)
                   |  required: String
                   |    val x: String = 42
                   |                    ^""".trimMargin()),
             ErrorDiagnostic(
                 Position(37, 1),
-                """path/to/package/Test.scala:37: error: type mismatch;
+                """type mismatch;
                   |  found   : String("test")
                   |  required: Int
                   |    val x: Int = "test"
                   |                 ^""".trimMargin())
         ))
-    Assertions.assertThat(diagnostics).containsExactlyInAnyOrderElementsOf(expected)
+    diagnostics shouldContainExactlyInAnyOrder expected
   }
 
   @Test
@@ -261,15 +259,15 @@ class DiagnosticsServiceTest {
             BuildTargetIdentifier("//server/src/test/java/org/jetbrains/bsp/bazel/server/diagnostics:diagnostics"),
             ErrorDiagnostic(
                 Position(12, 18),
-                """server/src/test/java/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsServiceTest.kt:12:18: error: type mismatch: inferred type is String but Int was expected
+                """type mismatch: inferred type is String but Int was expected
                   |val int: Int = "STRING"
                   |^""".trimMargin()),
             ErrorDiagnostic(
                 Position(13, 24),
-                """server/src/test/java/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsServiceTest.kt:13:24: error: the integer literal does not conform to the expected type String
+                """the integer literal does not conform to the expected type String
                   |val string: String = 1
                   |^""".trimMargin())))
-    Assertions.assertThat(diagnostics).containsExactlyInAnyOrderElementsOf(expected)
+    diagnostics shouldContainExactlyInAnyOrder expected
   }
 
   @Test
@@ -305,14 +303,14 @@ class DiagnosticsServiceTest {
             BuildTargetIdentifier("//project/src/main/scala/com/example/project:project"),
             ErrorDiagnostic(
                 Position(11, 1),
-                """project/src/main/scala/com/example/project/File1.scala:11: error: type mismatch;
+                """type mismatch;
                   |  found   : String("sd")
                   |  required: Int
                   |    val x: Int = "sd"
                   |                 ^""".trimMargin()),
             WarningDiagnostic(
                 Position(11, 1),
-                """project/src/main/scala/com/example/project/File1.scala:11: warning: local val x in method promote is never used
+                """local val x in method promote is never used
                    |  val x: Int = "sd"
                    |      ^""".trimMargin())),
         PublishDiagnosticsParams(
@@ -320,15 +318,15 @@ class DiagnosticsServiceTest {
             BuildTargetIdentifier("//project/src/main/scala/com/example/project:project"),
             WarningDiagnostic(
                 Position(26, 1),
-                """project/src/main/scala/com/example/project/File2.scala:26: warning: private val versionsWriter in object File2 is never used
+                """private val versionsWriter in object File2 is never used
                    |  private implicit val versionsWriter: ConfigWriter[Versions] = deriveWriter[Versions]
                    |                       ^""".trimMargin()),
             WarningDiagnostic(
                 Position(28, 1),
-                """project/src/main/scala/com/example/project/File2.scala:28: warning: private val File2ProtocolWriter in object File2 is never used
+                """private val File2ProtocolWriter in object File2 is never used
                    |private implicit val File2ProtocolWriter: ConfigWriter[File2Protocol] =
                    |                     ^""".trimMargin())))
-    Assertions.assertThat(diagnostics).containsExactlyInAnyOrderElementsOf(expected)
+    diagnostics shouldContainExactlyInAnyOrder expected
   }
 
   @Test
@@ -361,7 +359,7 @@ class DiagnosticsServiceTest {
             BuildTargetIdentifier("//intellij/release-tool/src/main/scala/com/intellij/releasetool:releasetool"),
             WarningDiagnostic(
                 Position(14, 1),
-                """intellij/release-tool/src/main/scala/com/intellij/releasetool/PluginResolver.scala:14: warning: match may not be exhaustive.
+                """match may not be exhaustive.
                    |It would fail on the following inputs: Bundled(_), BundledCrossVersion(_, _, _), Direct(_), Empty(), FromSources(_, _), Versioned((x: String forSome x not in "com.intellijUpdaterPlugin"), _, _)
                    |    key match {
                    |    ^""".trimMargin())),
@@ -370,10 +368,10 @@ class DiagnosticsServiceTest {
             BuildTargetIdentifier("//intellij/release-tool/src/main/scala/com/intellij/releasetool:releasetool"),
             WarningDiagnostic(
                 Position(29, 1),
-                """intellij/release-tool/src/main/scala/com/intellij/releasetool/Json.scala:29: warning: trait ScalaObjectMapper in package scala is deprecated (since 2.12.1): ScalaObjectMapper is deprecated because Manifests are not supported in Scala3, you might want to use ClassTagExtensions as a replacement
+                """trait ScalaObjectMapper in package scala is deprecated (since 2.12.1): ScalaObjectMapper is deprecated because Manifests are not supported in Scala3, you might want to use ClassTagExtensions as a replacement
                    |    val m = new ObjectMapper() with ScalaObjectMapper
                    |                                    ^""".trimMargin())))
-    Assertions.assertThat(diagnostics).containsExactlyInAnyOrderElementsOf(expected)
+    diagnostics shouldContainExactlyInAnyOrder expected
   }
 
   @Test
@@ -405,15 +403,15 @@ class DiagnosticsServiceTest {
             BuildTargetIdentifier(""),
             ErrorDiagnostic(
                 Position(20, 1),
-                """server/src/main/java/org/jetbrains/bsp/bazel/server/sync/ProjectResolver.java:20: error: symbol not found org.jetbrains.bsp.bazel.server.bsp.config.ProjectViewProvider
+                """symbol not found org.jetbrains.bsp.bazel.server.bsp.config.ProjectViewProvider
                    |import org.jetbrains.bsp.bazel.server.bsp.config.ProjectViewProvider;
                    |       ^""".trimMargin()),
             ErrorDiagnostic(
                 Position(37, 1),
-                """server/src/main/java/org/jetbrains/bsp/bazel/server/sync/ProjectResolver.java:37: error: could not resolve ProjectViewProvider
+                """could not resolve ProjectViewProvider
                    |      ProjectViewProvider projectViewProvider,
                    |      ^""".trimMargin())))
-    Assertions.assertThat(diagnostics).containsExactlyInAnyOrderElementsOf(expected)
+    diagnostics shouldContainExactlyInAnyOrder expected
   }
 
   private fun PublishDiagnosticsParams(
@@ -442,5 +440,4 @@ class DiagnosticsServiceTest {
     val bazelInfo = BasicBazelInfo("", workspacePath)
     return DiagnosticsService(bazelInfo).extractDiagnostics(output)
   }
-
 }

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsServiceTest.kt
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsServiceTest.kt
@@ -77,7 +77,7 @@ class DiagnosticsServiceTest {
             TextDocumentIdentifier("file:///user/workspace/path/to/package/Test.scala"),
             BuildTargetIdentifier("//path/to/package:test"),
             ErrorDiagnostic(
-                Position(3, 1),
+                Position(3, 18),
                 """type mismatch;
                   | found   : String("test")
                   | required: Int
@@ -132,7 +132,7 @@ class DiagnosticsServiceTest {
             TextDocumentIdentifier("file:///user/workspace/path/to/package/Test1.scala"),
             BuildTargetIdentifier("//path/to/package:test"),
             ErrorDiagnostic(
-                Position(21, 1),
+                Position(21, 21),
                 """type mismatch;
                   |  found   : Int(42)
                   |  required: String
@@ -143,7 +143,7 @@ class DiagnosticsServiceTest {
             TextDocumentIdentifier("file:///user/workspace/path/to/package/Test2.scala"),
             BuildTargetIdentifier("//path/to/package:test"),
             ErrorDiagnostic(
-                Position(37, 1),
+                Position(37, 18),
                 """type mismatch;
                   |  found   : String("test")
                   |  required: Int
@@ -198,14 +198,14 @@ class DiagnosticsServiceTest {
             TextDocumentIdentifier("file:///user/workspace/path/to/package/Test.scala"),
             BuildTargetIdentifier("//path/to/package:test"),
             ErrorDiagnostic(
-                Position(21, 1),
+                Position(21, 21),
                 """type mismatch;
                   |  found   : Int(42)
                   |  required: String
                   |    val x: String = 42
                   |                    ^""".trimMargin()),
             ErrorDiagnostic(
-                Position(37, 1),
+                Position(37, 18),
                 """type mismatch;
                   |  found   : String("test")
                   |  required: Int
@@ -302,14 +302,14 @@ class DiagnosticsServiceTest {
             TextDocumentIdentifier("file:///user/workspace/project/src/main/scala/com/example/project/File1.scala"),
             BuildTargetIdentifier("//project/src/main/scala/com/example/project:project"),
             ErrorDiagnostic(
-                Position(11, 1),
+                Position(11, 18),
                 """type mismatch;
                   |  found   : String("sd")
                   |  required: Int
                   |    val x: Int = "sd"
                   |                 ^""".trimMargin()),
             WarningDiagnostic(
-                Position(11, 1),
+                Position(11, 7),
                 """local val x in method promote is never used
                    |  val x: Int = "sd"
                    |      ^""".trimMargin())),
@@ -317,12 +317,12 @@ class DiagnosticsServiceTest {
             TextDocumentIdentifier("file:///user/workspace/project/src/main/scala/com/example/project/File2.scala"),
             BuildTargetIdentifier("//project/src/main/scala/com/example/project:project"),
             WarningDiagnostic(
-                Position(26, 1),
+                Position(26, 24),
                 """private val versionsWriter in object File2 is never used
                    |  private implicit val versionsWriter: ConfigWriter[Versions] = deriveWriter[Versions]
                    |                       ^""".trimMargin()),
             WarningDiagnostic(
-                Position(28, 1),
+                Position(28, 22),
                 """private val File2ProtocolWriter in object File2 is never used
                    |private implicit val File2ProtocolWriter: ConfigWriter[File2Protocol] =
                    |                     ^""".trimMargin())))
@@ -358,7 +358,7 @@ class DiagnosticsServiceTest {
             TextDocumentIdentifier("file:///user/workspace/intellij/release-tool/src/main/scala/com/intellij/releasetool/PluginResolver.scala"),
             BuildTargetIdentifier("//intellij/release-tool/src/main/scala/com/intellij/releasetool:releasetool"),
             WarningDiagnostic(
-                Position(14, 1),
+                Position(14, 5),
                 """match may not be exhaustive.
                    |It would fail on the following inputs: Bundled(_), BundledCrossVersion(_, _, _), Direct(_), Empty(), FromSources(_, _), Versioned((x: String forSome x not in "com.intellijUpdaterPlugin"), _, _)
                    |    key match {
@@ -367,7 +367,7 @@ class DiagnosticsServiceTest {
             TextDocumentIdentifier("file:///user/workspace/intellij/release-tool/src/main/scala/com/intellij/releasetool/Json.scala"),
             BuildTargetIdentifier("//intellij/release-tool/src/main/scala/com/intellij/releasetool:releasetool"),
             WarningDiagnostic(
-                Position(29, 1),
+                Position(29, 37),
                 """trait ScalaObjectMapper in package scala is deprecated (since 2.12.1): ScalaObjectMapper is deprecated because Manifests are not supported in Scala3, you might want to use ClassTagExtensions as a replacement
                    |    val m = new ObjectMapper() with ScalaObjectMapper
                    |                                    ^""".trimMargin())))
@@ -402,12 +402,12 @@ class DiagnosticsServiceTest {
             TextDocumentIdentifier("file:///user/workspace/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/ProjectResolver.java"),
             BuildTargetIdentifier(""),
             ErrorDiagnostic(
-                Position(20, 1),
+                Position(20, 8),
                 """symbol not found org.jetbrains.bsp.bazel.server.bsp.config.ProjectViewProvider
                    |import org.jetbrains.bsp.bazel.server.bsp.config.ProjectViewProvider;
                    |       ^""".trimMargin()),
             ErrorDiagnostic(
-                Position(37, 1),
+                Position(37, 7),
                 """could not resolve ProjectViewProvider
                    |      ProjectViewProvider projectViewProvider,
                    |      ^""".trimMargin())))

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsServiceTest.kt
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsServiceTest.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.bsp.bazel.server.diagnostics
 
 import ch.epfl.scala.bsp4j.*
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import org.assertj.core.api.Assertions
 import org.jetbrains.bsp.bazel.bazelrunner.BasicBazelInfo
 import org.junit.jupiter.api.Test
@@ -34,9 +35,9 @@ class DiagnosticsServiceTest {
             BuildTargetIdentifier("//path/to/package:test"),
             ErrorDiagnostic(
                 Position(12, 37),
-                "ERROR: /user/workspace/path/to/package/BUILD:12:37: in java_test rule //path/to/package:test: target '//path/to/another/package:lib' is not visible from target '//path/to/package:test'. Check the visibility declaration of the former target if you think the dependency is legitimate")
+                "in java_test rule //path/to/package:test: target '//path/to/another/package:lib' is not visible from target '//path/to/package:test'. Check the visibility declaration of the former target if you think the dependency is legitimate")
         ))
-    Assertions.assertThat(diagnostics).containsExactlyInAnyOrderElementsOf(expected)
+    diagnostics shouldContainExactlyInAnyOrder expected
   }
 
   @Test
@@ -437,7 +438,7 @@ class DiagnosticsServiceTest {
     return BspDiagnostic(Range(adjustedPosition, adjustedPosition), message).apply { this.severity = severity }
   }
 
-  private fun extractDiagnostics(output: String): List<PublishDiagnosticsParams>? {
+  private fun extractDiagnostics(output: String): List<PublishDiagnosticsParams> {
     val bazelInfo = BasicBazelInfo("", workspacePath)
     return DiagnosticsService(bazelInfo).extractDiagnostics(output)
   }


### PR DESCRIPTION
* diagnostic message doesnt contain path to file - intellij handles the hyperlinks
* for most of cases column number is inferred from number of spaces before `^` sign 
(see tests)

---

https://youtrack.jetbrains.com/issue/BAZEL-51

---
```
bazel test //server/src/test/java/org/jetbrains/bsp/bazel/server/diagnostics:DiagnosticsServiceTest
```
