### PR TITLE
[feature] `directories` and `derive_targets_from_directories` sections are now supported in project view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
 ## [Unreleased]
+
+### Features 🎉
 - Directories and derive_targets_from_directories sections are now available in project view files.
   | [#247](https://github.com/JetBrains/bazel-bsp/pull/247)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
 ## [Unreleased]
-
-...
+- Directories and derive_targets_from_directories sections are now available in project view files.
+  | [#247](https://github.com/JetBrains/bazel-bsp/pull/247)
 
 ## [2.1.0] - 11.05.2022
 

--- a/executioncontext/projectview/README.md
+++ b/executioncontext/projectview/README.md
@@ -140,13 +140,41 @@ The server will deduct bazel path from `$PATH`
 
 #### directories
 
-_We are working on it, you can expect support for this section in future releases._
+A list of directories to be mapped into bazel targets.
+
+You can use negative directories to have server ignore certain directories (
+e.g. `-executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/...`).
+
+##### example:
+
+```
+directories:
+  install/src/main/java/org/jetbrains/bsp/bazel/install
+  executioncontext/projectview/
+  -executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser
+```
+
+##### default:
+
+No directories included.
 
 ---
 
 #### derive_targets_from_directories
 
-_We are working on it, you can expect support for this section in future releases._
+A flag specifying if targets should be derived from list of directories in directories section.
+
+Flag is boolean value, so it can take either true or false. In the first case targets will be derived from directories, in the second they won't.
+
+##### example:
+
+```
+derive_targets_from_directories: true
+```
+
+##### default:
+
+Targets will not be derived from directories.
 
 ---
 

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/generator/DefaultProjectViewGenerator.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/generator/DefaultProjectViewGenerator.kt
@@ -19,6 +19,6 @@ object DefaultProjectViewGenerator : ProjectViewGenerator {
             ProjectViewJavaPathSectionGenerator.generatePrettyString(projectView.javaPath),
             ProjectViewBuildFlagsSectionGenerator.generatePrettyString(projectView.buildFlags),
             ProjectViewDirectoriesSectionGenerator.generatePrettyString(projectView.directories),
-            ProjectViewDeriveTargetsFromDirectoriesSectionGenerator.generatePrettyString(projectView.deriveTargetsFromDirectoriesSection)
+            ProjectViewDeriveTargetsFromDirectoriesSectionGenerator.generatePrettyString(projectView.deriveTargetsFromDirectories)
         ).joinToString(separator = "\n\n", postfix = "\n")
 }

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/generator/DefaultProjectViewGenerator.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/generator/DefaultProjectViewGenerator.kt
@@ -1,11 +1,7 @@
 package org.jetbrains.bsp.bazel.projectview.generator
 
 import io.vavr.control.Try
-import org.jetbrains.bsp.bazel.projectview.generator.sections.ProjectViewBazelPathSectionGenerator
-import org.jetbrains.bsp.bazel.projectview.generator.sections.ProjectViewBuildFlagsSectionGenerator
-import org.jetbrains.bsp.bazel.projectview.generator.sections.ProjectViewDebuggerAddressSectionGenerator
-import org.jetbrains.bsp.bazel.projectview.generator.sections.ProjectViewJavaPathSectionGenerator
-import org.jetbrains.bsp.bazel.projectview.generator.sections.ProjectViewTargetsSectionGenerator
+import org.jetbrains.bsp.bazel.projectview.generator.sections.*
 import org.jetbrains.bsp.bazel.projectview.model.ProjectView
 import org.jetbrains.bsp.bazel.utils.dope.DopeFiles
 import java.nio.file.Path
@@ -22,5 +18,7 @@ object DefaultProjectViewGenerator : ProjectViewGenerator {
             ProjectViewDebuggerAddressSectionGenerator.generatePrettyString(projectView.debuggerAddress),
             ProjectViewJavaPathSectionGenerator.generatePrettyString(projectView.javaPath),
             ProjectViewBuildFlagsSectionGenerator.generatePrettyString(projectView.buildFlags),
+            ProjectViewDirectoriesSectionGenerator.generatePrettyString(projectView.directories),
+            ProjectViewDeriveTargetsFromDirectoriesSectionGenerator.generatePrettyString(projectView.deriveTargetsFlag)
         ).joinToString(separator = "\n\n", postfix = "\n")
 }

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/generator/DefaultProjectViewGenerator.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/generator/DefaultProjectViewGenerator.kt
@@ -19,6 +19,6 @@ object DefaultProjectViewGenerator : ProjectViewGenerator {
             ProjectViewJavaPathSectionGenerator.generatePrettyString(projectView.javaPath),
             ProjectViewBuildFlagsSectionGenerator.generatePrettyString(projectView.buildFlags),
             ProjectViewDirectoriesSectionGenerator.generatePrettyString(projectView.directories),
-            ProjectViewDeriveTargetsFromDirectoriesSectionGenerator.generatePrettyString(projectView.deriveTargetsFlag)
+            ProjectViewDeriveTargetsFromDirectoriesSectionGenerator.generatePrettyString(projectView.deriveTargetsFromDirectoriesSection)
         ).joinToString(separator = "\n\n", postfix = "\n")
 }

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/generator/sections/ProjectViewExcludableListSectionGenerator.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/generator/sections/ProjectViewExcludableListSectionGenerator.kt
@@ -1,8 +1,11 @@
 package org.jetbrains.bsp.bazel.projectview.generator.sections
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDirectoriesSection
 import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewExcludableListSection
 import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewTargetsSection
+import java.nio.file.Path
+import kotlin.io.path.pathString
 
 abstract class ProjectViewExcludableListSectionGenerator<V, in T : ProjectViewExcludableListSection<V>> :
     ProjectViewListSectionGenerator<V, T>() {
@@ -42,4 +45,10 @@ object ProjectViewTargetsSectionGenerator :
     ProjectViewExcludableListSectionGenerator<BuildTargetIdentifier, ProjectViewTargetsSection>() {
 
     override fun generatePrettyStringForValue(value: BuildTargetIdentifier): String = value.uri
+}
+
+object ProjectViewDirectoriesSectionGenerator :
+        ProjectViewExcludableListSectionGenerator<Path, ProjectViewDirectoriesSection>() {
+
+    override fun generatePrettyStringForValue(value: Path): String = value.pathString
 }

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/generator/sections/ProjectViewSingletonSectionGenerator.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/generator/sections/ProjectViewSingletonSectionGenerator.kt
@@ -1,9 +1,6 @@
 package org.jetbrains.bsp.bazel.projectview.generator.sections
 
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewBazelPathSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDebuggerAddressSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewJavaPathSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewSingletonSection
+import org.jetbrains.bsp.bazel.projectview.model.sections.*
 
 abstract class ProjectViewSingletonSectionGenerator<in T : ProjectViewSingletonSection<*>> :
     ProjectViewSectionGenerator<T>() {
@@ -23,3 +20,5 @@ object ProjectViewDebuggerAddressSectionGenerator :
     ProjectViewSingletonSectionGenerator<ProjectViewDebuggerAddressSection>()
 
 object ProjectViewBazelPathSectionGenerator : ProjectViewSingletonSectionGenerator<ProjectViewBazelPathSection>()
+
+object ProjectViewDeriveTargetsFromDirectoriesSectionGenerator : ProjectViewSingletonSectionGenerator<ProjectViewDeriveTargetsFromDirectoriesSection>()

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/ProjectView.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/ProjectView.kt
@@ -23,8 +23,8 @@ data class ProjectView constructor(
     val buildFlags: ProjectViewBuildFlagsSection?,
     /** directories included and excluded from the project  */
     val directories: ProjectViewDirectoriesSection?,
-    /** directories included and excluded from the project  */
-    val deriveTargetsFlag: ProjectViewDeriveTargetsFlagSection?,
+    /** if set to true, relevant project targets will be automatically derived from the `directories` */
+    val deriveTargetsFlag: ProjectViewDeriveTargetsFromDirectoriesSection?,
 ) {
 
     class Builder constructor(
@@ -35,7 +35,7 @@ data class ProjectView constructor(
         private val javaPath: ProjectViewJavaPathSection? = null,
         private val buildFlags: ProjectViewBuildFlagsSection? = null,
         private val directories: ProjectViewDirectoriesSection? = null,
-        private val deriveTargetsFlag: ProjectViewDeriveTargetsFlagSection? = null,
+        private val deriveTargetsFlag: ProjectViewDeriveTargetsFromDirectoriesSection? = null,
     ) {
 
         fun build(): Try<ProjectView> {
@@ -182,7 +182,7 @@ data class ProjectView constructor(
         private fun combineJavaPathSection(importedProjectViews: List<ProjectView>): ProjectViewJavaPathSection? =
             javaPath ?: getLastImportedSingletonValue(importedProjectViews, ProjectView::javaPath)
 
-        private fun combineDeriveTargetFlagSection(importedProjectViews: List<ProjectView>): ProjectViewDeriveTargetsFlagSection? =
+        private fun combineDeriveTargetFlagSection(importedProjectViews: List<ProjectView>): ProjectViewDeriveTargetsFromDirectoriesSection? =
             deriveTargetsFlag ?: getLastImportedSingletonValue(importedProjectViews, ProjectView::deriveTargetsFlag)
 
         private fun <T : ProjectViewSingletonSection<*>> getLastImportedSingletonValue(

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/ProjectView.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/ProjectView.kt
@@ -24,7 +24,7 @@ data class ProjectView constructor(
     /** directories included and excluded from the project  */
     val directories: ProjectViewDirectoriesSection?,
     /** if set to true, relevant project targets will be automatically derived from the `directories` */
-    val deriveTargetsFromDirectoriesSection: ProjectViewDeriveTargetsFromDirectoriesSection?,
+    val deriveTargetsFromDirectories: ProjectViewDeriveTargetsFromDirectoriesSection?,
 ) {
 
     class Builder constructor(
@@ -35,7 +35,7 @@ data class ProjectView constructor(
         private val javaPath: ProjectViewJavaPathSection? = null,
         private val buildFlags: ProjectViewBuildFlagsSection? = null,
         private val directories: ProjectViewDirectoriesSection? = null,
-        private val deriveTargetsFromDirectoriesSection: ProjectViewDeriveTargetsFromDirectoriesSection? = null,
+        private val deriveTargetsFromDirectories: ProjectViewDeriveTargetsFromDirectoriesSection? = null,
     ) {
 
         fun build(): Try<ProjectView> {
@@ -49,7 +49,7 @@ data class ProjectView constructor(
                         + " java path: {},"
                         + " build flags: {},"
                         + " directories: {},"
-                        + " deriveTargetsFromDirectoriesSection: {}.",
+                        + " deriveTargetsFromDirectories: {}.",
                 imports,
                 targets,
                 bazelPath,
@@ -57,7 +57,7 @@ data class ProjectView constructor(
                 javaPath,
                 buildFlags,
                 directories,
-                deriveTargetsFromDirectoriesSection
+                deriveTargetsFromDirectories
             )
 
             return Try.sequence(imports)
@@ -73,7 +73,7 @@ data class ProjectView constructor(
             val javaPath = combineJavaPathSection(importedProjectViews)
             val buildFlags = combineBuildFlagsSection(importedProjectViews)
             val directories = combineDirectoriesSection(importedProjectViews)
-            val deriveTargetsFromDirectoriesSection = combineDeriveTargetFlagSection(importedProjectViews)
+            val deriveTargetsFromDirectories = combineDeriveTargetFlagSection(importedProjectViews)
             log.debug(
                 "Building project view with combined"
                         + " targets: {},"
@@ -87,9 +87,9 @@ data class ProjectView constructor(
                 debuggerAddress,
                 javaPath,
                 directories,
-                deriveTargetsFromDirectoriesSection
+                deriveTargetsFromDirectories
             )
-            return ProjectView(targets, bazelPath, debuggerAddress, javaPath, buildFlags, directories, deriveTargetsFromDirectoriesSection)
+            return ProjectView(targets, bazelPath, debuggerAddress, javaPath, buildFlags, directories, deriveTargetsFromDirectories)
         }
 
         private fun combineTargetsSection(importedProjectViews: List<ProjectView>): ProjectViewTargetsSection? {
@@ -183,7 +183,7 @@ data class ProjectView constructor(
             javaPath ?: getLastImportedSingletonValue(importedProjectViews, ProjectView::javaPath)
 
         private fun combineDeriveTargetFlagSection(importedProjectViews: List<ProjectView>): ProjectViewDeriveTargetsFromDirectoriesSection? =
-            deriveTargetsFromDirectoriesSection ?: getLastImportedSingletonValue(importedProjectViews, ProjectView::deriveTargetsFromDirectoriesSection)
+            deriveTargetsFromDirectories ?: getLastImportedSingletonValue(importedProjectViews, ProjectView::deriveTargetsFromDirectories)
 
         private fun <T : ProjectViewSingletonSection<*>> getLastImportedSingletonValue(
             importedProjectViews: List<ProjectView>, sectionGetter: (ProjectView) -> T?

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/ProjectView.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/ProjectView.kt
@@ -24,7 +24,7 @@ data class ProjectView constructor(
     /** directories included and excluded from the project  */
     val directories: ProjectViewDirectoriesSection?,
     /** if set to true, relevant project targets will be automatically derived from the `directories` */
-    val deriveTargetsFlag: ProjectViewDeriveTargetsFromDirectoriesSection?,
+    val deriveTargetsFromDirectoriesSection: ProjectViewDeriveTargetsFromDirectoriesSection?,
 ) {
 
     class Builder constructor(
@@ -35,7 +35,7 @@ data class ProjectView constructor(
         private val javaPath: ProjectViewJavaPathSection? = null,
         private val buildFlags: ProjectViewBuildFlagsSection? = null,
         private val directories: ProjectViewDirectoriesSection? = null,
-        private val deriveTargetsFlag: ProjectViewDeriveTargetsFromDirectoriesSection? = null,
+        private val deriveTargetsFromDirectoriesSection: ProjectViewDeriveTargetsFromDirectoriesSection? = null,
     ) {
 
         fun build(): Try<ProjectView> {
@@ -49,7 +49,7 @@ data class ProjectView constructor(
                         + " java path: {},"
                         + " build flags: {},"
                         + " directories: {},"
-                        + " deriveTargetsFlag: {}.",
+                        + " deriveTargetsFromDirectoriesSection: {}.",
                 imports,
                 targets,
                 bazelPath,
@@ -57,7 +57,7 @@ data class ProjectView constructor(
                 javaPath,
                 buildFlags,
                 directories,
-                deriveTargetsFlag
+                deriveTargetsFromDirectoriesSection
             )
 
             return Try.sequence(imports)
@@ -73,7 +73,7 @@ data class ProjectView constructor(
             val javaPath = combineJavaPathSection(importedProjectViews)
             val buildFlags = combineBuildFlagsSection(importedProjectViews)
             val directories = combineDirectoriesSection(importedProjectViews)
-            val deriveTargetsFlag = combineDeriveTargetFlagSection(importedProjectViews)
+            val deriveTargetsFromDirectoriesSection = combineDeriveTargetFlagSection(importedProjectViews)
             log.debug(
                 "Building project view with combined"
                         + " targets: {},"
@@ -87,9 +87,9 @@ data class ProjectView constructor(
                 debuggerAddress,
                 javaPath,
                 directories,
-                deriveTargetsFlag
+                deriveTargetsFromDirectoriesSection
             )
-            return ProjectView(targets, bazelPath, debuggerAddress, javaPath, buildFlags, directories, deriveTargetsFlag)
+            return ProjectView(targets, bazelPath, debuggerAddress, javaPath, buildFlags, directories, deriveTargetsFromDirectoriesSection)
         }
 
         private fun combineTargetsSection(importedProjectViews: List<ProjectView>): ProjectViewTargetsSection? {
@@ -183,7 +183,7 @@ data class ProjectView constructor(
             javaPath ?: getLastImportedSingletonValue(importedProjectViews, ProjectView::javaPath)
 
         private fun combineDeriveTargetFlagSection(importedProjectViews: List<ProjectView>): ProjectViewDeriveTargetsFromDirectoriesSection? =
-            deriveTargetsFlag ?: getLastImportedSingletonValue(importedProjectViews, ProjectView::deriveTargetsFlag)
+            deriveTargetsFromDirectoriesSection ?: getLastImportedSingletonValue(importedProjectViews, ProjectView::deriveTargetsFromDirectoriesSection)
 
         private fun <T : ProjectViewSingletonSection<*>> getLastImportedSingletonValue(
             importedProjectViews: List<ProjectView>, sectionGetter: (ProjectView) -> T?

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/ProjectView.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/ProjectView.kt
@@ -3,14 +3,7 @@ package org.jetbrains.bsp.bazel.projectview.model
 import io.vavr.collection.Seq
 import io.vavr.control.Try
 import org.apache.logging.log4j.LogManager
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewBazelPathSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewBuildFlagsSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDebuggerAddressSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewExcludableListSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewJavaPathSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewListSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewSingletonSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewTargetsSection
+import org.jetbrains.bsp.bazel.projectview.model.sections.*
 
 /**
  * Representation of the project view file.
@@ -28,6 +21,10 @@ data class ProjectView constructor(
     val javaPath: ProjectViewJavaPathSection?,
     /** bazel flags added to all bazel command invocations  */
     val buildFlags: ProjectViewBuildFlagsSection?,
+    /** directories included and excluded from the project  */
+    val directories: ProjectViewDirectoriesSection?,
+    /** directories included and excluded from the project  */
+    val deriveTargetsFlag: ProjectViewDeriveTargetsFlagSection?,
 ) {
 
     class Builder constructor(
@@ -37,6 +34,8 @@ data class ProjectView constructor(
         private val debuggerAddress: ProjectViewDebuggerAddressSection? = null,
         private val javaPath: ProjectViewJavaPathSection? = null,
         private val buildFlags: ProjectViewBuildFlagsSection? = null,
+        private val directories: ProjectViewDirectoriesSection? = null,
+        private val deriveTargetsFlag: ProjectViewDeriveTargetsFlagSection? = null,
     ) {
 
         fun build(): Try<ProjectView> {
@@ -48,13 +47,17 @@ data class ProjectView constructor(
                         + " bazel path: {},"
                         + " debugger address: {},"
                         + " java path: {},"
-                        + " build flags: {}.",
+                        + " build flags: {},"
+                        + " directories: {},"
+                        + " deriveTargetsFlag: {}.",
                 imports,
                 targets,
                 bazelPath,
                 debuggerAddress,
                 javaPath,
-                buildFlags
+                buildFlags,
+                directories,
+                deriveTargetsFlag
             )
 
             return Try.sequence(imports)
@@ -69,18 +72,24 @@ data class ProjectView constructor(
             val debuggerAddress = combineDebuggerAddressSection(importedProjectViews)
             val javaPath = combineJavaPathSection(importedProjectViews)
             val buildFlags = combineBuildFlagsSection(importedProjectViews)
+            val directories = combineDirectoriesSection(importedProjectViews)
+            val deriveTargetsFlag = combineDeriveTargetFlagSection(importedProjectViews)
             log.debug(
                 "Building project view with combined"
                         + " targets: {},"
                         + " bazel path: {},"
                         + " debugger address: {},"
-                        + " java path: {}.",
+                        + " java path: {},"
+                        + " directories: {},"
+                        + " deriveTargetsFlag: {}.",
                 targets,
                 bazelPath,
                 debuggerAddress,
-                javaPath
+                javaPath,
+                directories,
+                deriveTargetsFlag
             )
-            return ProjectView(targets, bazelPath, debuggerAddress, javaPath, buildFlags)
+            return ProjectView(targets, bazelPath, debuggerAddress, javaPath, buildFlags, directories, deriveTargetsFlag)
         }
 
         private fun combineTargetsSection(importedProjectViews: List<ProjectView>): ProjectViewTargetsSection? {
@@ -112,6 +121,26 @@ data class ProjectView constructor(
             )
 
             return createInstanceOfListSectionOrNull(flags, ::ProjectViewBuildFlagsSection)
+        }
+
+        private fun combineDirectoriesSection(importedProjectViews: List<ProjectView>): ProjectViewDirectoriesSection? {
+            val includedTargets = combineListValuesWithImported(
+                    importedProjectViews,
+                    directories,
+                    ProjectView::directories,
+                    ProjectViewDirectoriesSection::values
+            )
+            val excludedTargets = combineListValuesWithImported(
+                    importedProjectViews,
+                    directories,
+                    ProjectView::directories,
+                    ProjectViewDirectoriesSection::excludedValues
+            )
+            return createInstanceOfExcludableListSectionOrNull(
+                    includedTargets,
+                    excludedTargets,
+                    ::ProjectViewDirectoriesSection
+            )
         }
 
         private fun <V, T : ProjectViewListSection<V>> combineListValuesWithImported(
@@ -153,6 +182,8 @@ data class ProjectView constructor(
         private fun combineJavaPathSection(importedProjectViews: List<ProjectView>): ProjectViewJavaPathSection? =
             javaPath ?: getLastImportedSingletonValue(importedProjectViews, ProjectView::javaPath)
 
+        private fun combineDeriveTargetFlagSection(importedProjectViews: List<ProjectView>): ProjectViewDeriveTargetsFlagSection? =
+            deriveTargetsFlag ?: getLastImportedSingletonValue(importedProjectViews, ProjectView::deriveTargetsFlag)
 
         private fun <T : ProjectViewSingletonSection<*>> getLastImportedSingletonValue(
             importedProjectViews: List<ProjectView>, sectionGetter: (ProjectView) -> T?

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/sections/ProjectViewExcludableListSection.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/sections/ProjectViewExcludableListSection.kt
@@ -16,3 +16,13 @@ data class ProjectViewTargetsSection(
         const val SECTION_NAME = "targets"
     }
 }
+
+data class ProjectViewDirectoriesSection(
+        override val values: List<BuildTargetIdentifier>,
+        override val excludedValues: List<BuildTargetIdentifier>,
+) : ProjectViewExcludableListSection<BuildTargetIdentifier>(SECTION_NAME) {
+
+    companion object {
+        const val SECTION_NAME = "directories"
+    }
+}

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/sections/ProjectViewExcludableListSection.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/sections/ProjectViewExcludableListSection.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.bsp.bazel.projectview.model.sections
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import java.nio.file.Path
 
 sealed class ProjectViewExcludableListSection<T> constructor(sectionName: String) :
     ProjectViewListSection<T>(sectionName) {
@@ -18,9 +19,9 @@ data class ProjectViewTargetsSection(
 }
 
 data class ProjectViewDirectoriesSection(
-        override val values: List<BuildTargetIdentifier>,
-        override val excludedValues: List<BuildTargetIdentifier>,
-) : ProjectViewExcludableListSection<BuildTargetIdentifier>(SECTION_NAME) {
+        override val values: List<Path>,
+        override val excludedValues: List<Path>,
+) : ProjectViewExcludableListSection<Path>(SECTION_NAME) {
 
     companion object {
         const val SECTION_NAME = "directories"

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/sections/ProjectViewSingletonSection.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/sections/ProjectViewSingletonSection.kt
@@ -20,6 +20,13 @@ data class ProjectViewDebuggerAddressSection(override val value: String) :
     }
 }
 
+data class ProjectViewDeriveTargetsFlagSection(override val value: Boolean) :
+        ProjectViewSingletonSection<Boolean>(SECTION_NAME) {
+    companion object {
+        const val SECTION_NAME = "derive_targets_from_directories"
+    }
+}
+
 data class ProjectViewBazelPathSection(override val value: Path) :
     ProjectViewSingletonSection<Path>(SECTION_NAME) {
     companion object {

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/sections/ProjectViewSingletonSection.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/model/sections/ProjectViewSingletonSection.kt
@@ -20,7 +20,7 @@ data class ProjectViewDebuggerAddressSection(override val value: String) :
     }
 }
 
-data class ProjectViewDeriveTargetsFlagSection(override val value: Boolean) :
+data class ProjectViewDeriveTargetsFromDirectoriesSection(override val value: Boolean) :
         ProjectViewSingletonSection<Boolean>(SECTION_NAME) {
     companion object {
         const val SECTION_NAME = "derive_targets_from_directories"

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParser.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParser.kt
@@ -43,7 +43,7 @@ open class DefaultProjectViewParser : ProjectViewParser {
             javaPath = ProjectViewJavaPathSectionParser.parse(rawSections),
             buildFlags = ProjectViewBuildFlagsSectionParser.parse(rawSections),
             directories = ProjectViewDirectoriesSectionParser.parse(rawSections),
-            deriveTargetsFlag = ProjectViewDeriveTargetsFlagSectionParser.parse(rawSections),
+            deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSectionParser.parse(rawSections),
         ).build()
     }
 

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParser.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParser.kt
@@ -43,7 +43,7 @@ open class DefaultProjectViewParser : ProjectViewParser {
             javaPath = ProjectViewJavaPathSectionParser.parse(rawSections),
             buildFlags = ProjectViewBuildFlagsSectionParser.parse(rawSections),
             directories = ProjectViewDirectoriesSectionParser.parse(rawSections),
-            deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSectionParser.parse(rawSections),
+            deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSectionParser.parse(rawSections),
         ).build()
     }
 

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParser.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParser.kt
@@ -43,7 +43,7 @@ open class DefaultProjectViewParser : ProjectViewParser {
             javaPath = ProjectViewJavaPathSectionParser.parse(rawSections),
             buildFlags = ProjectViewBuildFlagsSectionParser.parse(rawSections),
             directories = ProjectViewDirectoriesSectionParser.parse(rawSections),
-            deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSectionParser.parse(rawSections),
+            deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSectionParser.parse(rawSections),
         ).build()
     }
 

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParser.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParser.kt
@@ -3,11 +3,7 @@ package org.jetbrains.bsp.bazel.projectview.parser
 import io.vavr.control.Try
 import org.apache.logging.log4j.LogManager
 import org.jetbrains.bsp.bazel.projectview.model.ProjectView
-import org.jetbrains.bsp.bazel.projectview.parser.sections.ProjectViewBazelPathSectionParser
-import org.jetbrains.bsp.bazel.projectview.parser.sections.ProjectViewBuildFlagsSectionParser
-import org.jetbrains.bsp.bazel.projectview.parser.sections.ProjectViewDebuggerAddressSectionParser
-import org.jetbrains.bsp.bazel.projectview.parser.sections.ProjectViewJavaPathSectionParser
-import org.jetbrains.bsp.bazel.projectview.parser.sections.ProjectViewTargetsSectionParser
+import org.jetbrains.bsp.bazel.projectview.parser.sections.*
 import org.jetbrains.bsp.bazel.projectview.parser.splitter.ProjectViewRawSections
 import org.jetbrains.bsp.bazel.projectview.parser.splitter.ProjectViewSectionSplitter
 import org.jetbrains.bsp.bazel.utils.dope.DopeFiles
@@ -46,6 +42,8 @@ open class DefaultProjectViewParser : ProjectViewParser {
             debuggerAddress = ProjectViewDebuggerAddressSectionParser.parse(rawSections),
             javaPath = ProjectViewJavaPathSectionParser.parse(rawSections),
             buildFlags = ProjectViewBuildFlagsSectionParser.parse(rawSections),
+            directories = ProjectViewDirectoriesSectionParser.parse(rawSections),
+            deriveTargetsFlag = ProjectViewDeriveTargetsFlagSectionParser.parse(rawSections),
         ).build()
     }
 

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/sections/ProjectViewExcludableListSectionParser.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/sections/ProjectViewExcludableListSectionParser.kt
@@ -4,6 +4,8 @@ import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDirectoriesSection
 import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewExcludableListSection
 import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewTargetsSection
+import java.nio.file.Path
+import kotlin.io.path.Path
 
 /**
  * Implementation of excludable list section parser.
@@ -71,11 +73,11 @@ object ProjectViewTargetsSectionParser :
 }
 
 object ProjectViewDirectoriesSectionParser :
-        ProjectViewExcludableListSectionParser<BuildTargetIdentifier, ProjectViewDirectoriesSection>(ProjectViewDirectoriesSection.SECTION_NAME) {
+        ProjectViewExcludableListSectionParser<Path, ProjectViewDirectoriesSection>(ProjectViewDirectoriesSection.SECTION_NAME) {
 
-    override fun mapRawValues(rawValue: String): BuildTargetIdentifier = BuildTargetIdentifier(rawValue)
+    override fun mapRawValues(rawValue: String): Path = Path(rawValue)
 
     override fun createInstance(
-            includedValues: List<BuildTargetIdentifier>, excludedValues: List<BuildTargetIdentifier>
+            includedValues: List<Path>, excludedValues: List<Path>
     ): ProjectViewDirectoriesSection = ProjectViewDirectoriesSection(includedValues, excludedValues)
 }

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/sections/ProjectViewExcludableListSectionParser.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/sections/ProjectViewExcludableListSectionParser.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.bsp.bazel.projectview.parser.sections
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDirectoriesSection
 import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewExcludableListSection
 import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewTargetsSection
 
@@ -67,4 +68,14 @@ object ProjectViewTargetsSectionParser :
     override fun createInstance(
         includedValues: List<BuildTargetIdentifier>, excludedValues: List<BuildTargetIdentifier>
     ): ProjectViewTargetsSection = ProjectViewTargetsSection(includedValues, excludedValues)
+}
+
+object ProjectViewDirectoriesSectionParser :
+        ProjectViewExcludableListSectionParser<BuildTargetIdentifier, ProjectViewDirectoriesSection>(ProjectViewDirectoriesSection.SECTION_NAME) {
+
+    override fun mapRawValues(rawValue: String): BuildTargetIdentifier = BuildTargetIdentifier(rawValue)
+
+    override fun createInstance(
+            includedValues: List<BuildTargetIdentifier>, excludedValues: List<BuildTargetIdentifier>
+    ): ProjectViewDirectoriesSection = ProjectViewDirectoriesSection(includedValues, excludedValues)
 }

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/sections/ProjectViewSingletonSectionParser.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/sections/ProjectViewSingletonSectionParser.kt
@@ -58,13 +58,13 @@ object ProjectViewDebuggerAddressSectionParser :
         ProjectViewDebuggerAddressSection(value)
 }
 
-object ProjectViewDeriveTargetsFlagSectionParser :
-        ProjectViewSingletonSectionParser<Boolean, ProjectViewDeriveTargetsFlagSection>(ProjectViewDeriveTargetsFlagSection.SECTION_NAME) {
+object ProjectViewDeriveTargetsFromDirectoriesSectionParser :
+        ProjectViewSingletonSectionParser<Boolean, ProjectViewDeriveTargetsFromDirectoriesSection>(ProjectViewDeriveTargetsFromDirectoriesSection.SECTION_NAME) {
 
     override fun mapRawValue(rawValue: String): Boolean = rawValue.toBoolean()
 
-    override fun createInstance(value: Boolean): ProjectViewDeriveTargetsFlagSection =
-            ProjectViewDeriveTargetsFlagSection(value)
+    override fun createInstance(value: Boolean): ProjectViewDeriveTargetsFromDirectoriesSection =
+            ProjectViewDeriveTargetsFromDirectoriesSection(value)
 }
 
 object ProjectViewJavaPathSectionParser :

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/sections/ProjectViewSingletonSectionParser.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/sections/ProjectViewSingletonSectionParser.kt
@@ -1,10 +1,7 @@
 package org.jetbrains.bsp.bazel.projectview.parser.sections
 
 import org.apache.logging.log4j.LogManager
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewBazelPathSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDebuggerAddressSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewJavaPathSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewSingletonSection
+import org.jetbrains.bsp.bazel.projectview.model.sections.*
 import org.jetbrains.bsp.bazel.projectview.parser.splitter.ProjectViewRawSections
 import java.nio.file.Path
 import kotlin.io.path.Path
@@ -61,6 +58,14 @@ object ProjectViewDebuggerAddressSectionParser :
         ProjectViewDebuggerAddressSection(value)
 }
 
+object ProjectViewDeriveTargetsFlagSectionParser :
+        ProjectViewSingletonSectionParser<Boolean, ProjectViewDeriveTargetsFlagSection>(ProjectViewDeriveTargetsFlagSection.SECTION_NAME) {
+
+    override fun mapRawValue(rawValue: String): Boolean = rawValue.toBoolean()
+
+    override fun createInstance(value: Boolean): ProjectViewDeriveTargetsFlagSection =
+            ProjectViewDeriveTargetsFlagSection(value)
+}
 
 object ProjectViewJavaPathSectionParser :
     ProjectViewSingletonSectionParser<Path, ProjectViewJavaPathSection>(ProjectViewJavaPathSection.SECTION_NAME) {
@@ -69,3 +74,5 @@ object ProjectViewJavaPathSectionParser :
 
     override fun createInstance(value: Path): ProjectViewJavaPathSection = ProjectViewJavaPathSection(value)
 }
+
+

--- a/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/sections/ProjectViewSingletonSectionParser.kt
+++ b/executioncontext/projectview/src/main/java/org/jetbrains/bsp/bazel/projectview/parser/sections/ProjectViewSingletonSectionParser.kt
@@ -74,5 +74,3 @@ object ProjectViewJavaPathSectionParser :
 
     override fun createInstance(value: Path): ProjectViewJavaPathSection = ProjectViewJavaPathSection(value)
 }
-
-

--- a/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/generator/DefaultProjectViewGeneratorTest.kt
+++ b/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/generator/DefaultProjectViewGeneratorTest.kt
@@ -31,6 +31,8 @@ class DefaultProjectViewGeneratorTest {
                 debuggerAddress = null,
                 javaPath = null,
                 buildFlags = null,
+                directories = null,
+                deriveTargetsFlag = null
             )
 
             // when
@@ -59,6 +61,8 @@ class DefaultProjectViewGeneratorTest {
                 debuggerAddress = null,
                 javaPath = null,
                 buildFlags = null,
+                directories = null,
+                deriveTargetsFlag = null
             )
 
             // when
@@ -87,6 +91,8 @@ class DefaultProjectViewGeneratorTest {
                 debuggerAddress = null,
                 javaPath = null,
                 buildFlags = null,
+                directories = null,
+                deriveTargetsFlag = null
             )
 
             // when
@@ -110,6 +116,8 @@ class DefaultProjectViewGeneratorTest {
                 debuggerAddress = ProjectViewDebuggerAddressSection("localhost:8000"),
                 javaPath = null,
                 buildFlags = null,
+                directories = null,
+                deriveTargetsFlag = null
             )
 
             // when
@@ -133,6 +141,8 @@ class DefaultProjectViewGeneratorTest {
                 debuggerAddress = null,
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = null,
+                directories = null,
+                deriveTargetsFlag = null
             )
 
             // when
@@ -162,6 +172,8 @@ class DefaultProjectViewGeneratorTest {
                         "--build_flag3=value3",
                     )
                 ),
+                    directories = null,
+                    deriveTargetsFlag = null
             )
 
             // when
@@ -188,6 +200,8 @@ class DefaultProjectViewGeneratorTest {
                 debuggerAddress = ProjectViewDebuggerAddressSection("localhost:8000"),
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = ProjectViewBuildFlagsSection(emptyList()),
+                    directories = null,
+                    deriveTargetsFlag = null
             )
 
             // when
@@ -231,6 +245,8 @@ class DefaultProjectViewGeneratorTest {
                         "--build_flag3=value3",
                     )
                 ),
+                    directories = null,
+                    deriveTargetsFlag = null
             )
 
             // when
@@ -280,6 +296,8 @@ class DefaultProjectViewGeneratorTest {
                         "--build_flag3=value3",
                     )
                 ),
+                    directories = null,
+                    deriveTargetsFlag = null
             )
 
             // when
@@ -342,6 +360,8 @@ class DefaultProjectViewGeneratorTest {
                         "--build_flag3=value3",
                     )
                 ),
+                    directories = null,
+                    deriveTargetsFlag = null
             )
 
             // when
@@ -402,6 +422,8 @@ class DefaultProjectViewGeneratorTest {
                         "--build_flag3=value3",
                     )
                 ),
+                    directories = null,
+                    deriveTargetsFlag = null
             )
 
             // when
@@ -445,6 +467,8 @@ class DefaultProjectViewGeneratorTest {
                 debuggerAddress = ProjectViewDebuggerAddressSection("localhost:8000"),
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = ProjectViewBuildFlagsSection(emptyList()),
+                    directories = null,
+                    deriveTargetsFlag = null
             )
 
             val parser = DefaultProjectViewParser()
@@ -463,6 +487,8 @@ class DefaultProjectViewGeneratorTest {
                 debuggerAddress = ProjectViewDebuggerAddressSection("localhost:8000"),
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = null,
+                    directories = null,
+                    deriveTargetsFlag = null
             )
             parsedProjectViewTry.get() shouldBe expectedProjectView
         }
@@ -490,6 +516,8 @@ class DefaultProjectViewGeneratorTest {
                         "--build_flag3=value3",
                     )
                 ),
+                    directories = null,
+                    deriveTargetsFlag = null
             )
 
             val parser = DefaultProjectViewParser()
@@ -532,6 +560,8 @@ class DefaultProjectViewGeneratorTest {
                         "--build_flag3=value3",
                     )
                 ),
+                    directories = null,
+                    deriveTargetsFlag = null
             )
 
             val parser = DefaultProjectViewParser()

--- a/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/generator/DefaultProjectViewGeneratorTest.kt
+++ b/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/generator/DefaultProjectViewGeneratorTest.kt
@@ -3,11 +3,7 @@ package org.jetbrains.bsp.bazel.projectview.generator
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import io.kotest.matchers.shouldBe
 import org.jetbrains.bsp.bazel.projectview.model.ProjectView
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewBazelPathSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewBuildFlagsSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDebuggerAddressSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewJavaPathSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewTargetsSection
+import org.jetbrains.bsp.bazel.projectview.model.sections.*
 import org.jetbrains.bsp.bazel.projectview.parser.DefaultProjectViewParser
 import org.jetbrains.bsp.bazel.utils.dope.DopeTemp
 import org.junit.jupiter.api.DisplayName
@@ -15,6 +11,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
 import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class DefaultProjectViewGeneratorTest {
 
@@ -172,8 +169,8 @@ class DefaultProjectViewGeneratorTest {
                         "--build_flag3=value3",
                     )
                 ),
-                    directories = null,
-                    deriveTargetsFlag = null
+                directories = null,
+                deriveTargetsFlag = null
             )
 
             // when
@@ -192,6 +189,71 @@ class DefaultProjectViewGeneratorTest {
         }
 
         @Test
+        fun `should return pretty string only with directories for project view only with directories`() {
+            // given
+            val projectView = ProjectView(
+                    targets = null,
+                    bazelPath = null,
+                    debuggerAddress = null,
+                    javaPath = null,
+                    buildFlags = null,
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir1"),
+                                    Path("included_dir2"),
+                                    Path("included_dir3")
+                            ),
+                            listOf(
+                                    Path("excluded_dir1"),
+                                    Path("excluded_dir2")
+                            )
+                    ),
+                    deriveTargetsFlag = null
+            )
+
+            // when
+            val generatedString = DefaultProjectViewGenerator.generatePrettyString(projectView)
+
+            // then
+            val expectedGeneratedString =
+                """
+                directories:
+                    included_dir1
+                    included_dir2
+                    included_dir3
+                    -excluded_dir1
+                    -excluded_dir2
+
+                """.trimIndent()
+            generatedString shouldBe expectedGeneratedString
+        }
+
+        @Test
+        fun `should return pretty string only with derive_targets_from_directories for project view only with deriveTargetsFlag`() {
+            // given
+            val projectView = ProjectView(
+                    targets = null,
+                    bazelPath = null,
+                    debuggerAddress = null,
+                    javaPath = null,
+                    buildFlags = null,
+                    directories = null,
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+            )
+
+            // when
+            val generatedString = DefaultProjectViewGenerator.generatePrettyString(projectView)
+
+            // then
+            val expectedGeneratedString =
+                """
+                derive_targets_from_directories: true
+
+                """.trimIndent()
+            generatedString shouldBe expectedGeneratedString
+        }
+
+        @Test
         fun `should return pretty string with project view for project view with empty list sections`() {
             // given
             val projectView = ProjectView(
@@ -200,8 +262,8 @@ class DefaultProjectViewGeneratorTest {
                 debuggerAddress = ProjectViewDebuggerAddressSection("localhost:8000"),
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = ProjectViewBuildFlagsSection(emptyList()),
-                    directories = null,
-                    deriveTargetsFlag = null
+                directories = ProjectViewDirectoriesSection(emptyList(), emptyList()),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             // when
@@ -219,7 +281,11 @@ class DefaultProjectViewGeneratorTest {
                 java_path: /path/to/java
 
                 build_flags:
-
+                
+                directories:
+                
+                derive_targets_from_directories: true
+                
                 """.trimIndent()
             generatedString shouldBe expectedGeneratedString
         }
@@ -245,8 +311,8 @@ class DefaultProjectViewGeneratorTest {
                         "--build_flag3=value3",
                     )
                 ),
-                    directories = null,
-                    deriveTargetsFlag = null
+                directories = null,
+                deriveTargetsFlag = null
             )
 
             // when
@@ -296,8 +362,18 @@ class DefaultProjectViewGeneratorTest {
                         "--build_flag3=value3",
                     )
                 ),
-                    directories = null,
-                    deriveTargetsFlag = null
+                directories = ProjectViewDirectoriesSection(
+                        listOf(
+                                Path("included_dir1"),
+                                Path("included_dir2"),
+                                Path("included_dir3")
+                        ),
+                        listOf(
+                                Path("excluded_dir1"),
+                                Path("excluded_dir2")
+                        )
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             // when
@@ -324,6 +400,15 @@ class DefaultProjectViewGeneratorTest {
                     --build_flag2=value2
                     --build_flag3=value3
 
+                directories:
+                    included_dir1
+                    included_dir2
+                    included_dir3
+                    -excluded_dir1
+                    -excluded_dir2
+               
+                derive_targets_from_directories: true
+                
                 """.trimIndent()
             generatedString shouldBe expectedGeneratedString
         }
@@ -360,8 +445,18 @@ class DefaultProjectViewGeneratorTest {
                         "--build_flag3=value3",
                     )
                 ),
-                    directories = null,
-                    deriveTargetsFlag = null
+                directories = ProjectViewDirectoriesSection(
+                        listOf(
+                                Path("included_dir1"),
+                                Path("included_dir2"),
+                                Path("included_dir3")
+                        ),
+                        listOf(
+                                Path("excluded_dir1"),
+                                Path("excluded_dir2")
+                        )
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             // when
@@ -390,6 +485,15 @@ class DefaultProjectViewGeneratorTest {
                     --build_flag2=value2
                     --build_flag3=value3
 
+                directories:
+                    included_dir1
+                    included_dir2
+                    included_dir3
+                    -excluded_dir1
+                    -excluded_dir2
+               
+                derive_targets_from_directories: true
+                
                 """.trimIndent()
             Files.readString(filePath) shouldBe expectedFileContent
         }
@@ -422,8 +526,18 @@ class DefaultProjectViewGeneratorTest {
                         "--build_flag3=value3",
                     )
                 ),
-                    directories = null,
-                    deriveTargetsFlag = null
+                directories = ProjectViewDirectoriesSection(
+                        listOf(
+                                Path("included_dir1"),
+                                Path("included_dir2"),
+                                Path("included_dir3")
+                        ),
+                        listOf(
+                                Path("excluded_dir1"),
+                                Path("excluded_dir2")
+                        )
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             // when
@@ -452,6 +566,15 @@ class DefaultProjectViewGeneratorTest {
                     --build_flag2=value2
                     --build_flag3=value3
 
+                directories:
+                    included_dir1
+                    included_dir2
+                    included_dir3
+                    -excluded_dir1
+                    -excluded_dir2
+               
+                derive_targets_from_directories: true
+                
                 """.trimIndent()
             Files.readString(filePath) shouldBe expectedFileContent
         }
@@ -467,8 +590,8 @@ class DefaultProjectViewGeneratorTest {
                 debuggerAddress = ProjectViewDebuggerAddressSection("localhost:8000"),
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = ProjectViewBuildFlagsSection(emptyList()),
-                    directories = null,
-                    deriveTargetsFlag = null
+                directories = ProjectViewDirectoriesSection(emptyList(), emptyList()),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             val parser = DefaultProjectViewParser()
@@ -487,8 +610,8 @@ class DefaultProjectViewGeneratorTest {
                 debuggerAddress = ProjectViewDebuggerAddressSection("localhost:8000"),
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = null,
-                    directories = null,
-                    deriveTargetsFlag = null
+                directories = null,
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             parsedProjectViewTry.get() shouldBe expectedProjectView
         }
@@ -516,8 +639,8 @@ class DefaultProjectViewGeneratorTest {
                         "--build_flag3=value3",
                     )
                 ),
-                    directories = null,
-                    deriveTargetsFlag = null
+                directories = null,
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             val parser = DefaultProjectViewParser()
@@ -560,8 +683,18 @@ class DefaultProjectViewGeneratorTest {
                         "--build_flag3=value3",
                     )
                 ),
-                    directories = null,
-                    deriveTargetsFlag = null
+                directories = ProjectViewDirectoriesSection(
+                        listOf(
+                                Path("included_dir1"),
+                                Path("included_dir2"),
+                                Path("included_dir3")
+                        ),
+                        listOf(
+                                Path("excluded_dir1"),
+                                Path("excluded_dir2")
+                        )
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             val parser = DefaultProjectViewParser()

--- a/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/generator/DefaultProjectViewGeneratorTest.kt
+++ b/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/generator/DefaultProjectViewGeneratorTest.kt
@@ -29,7 +29,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = null,
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFlag = null
+                deriveTargetsFromDirectoriesSection = null
             )
 
             // when
@@ -59,7 +59,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = null,
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFlag = null
+                deriveTargetsFromDirectoriesSection = null
             )
 
             // when
@@ -89,7 +89,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = null,
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFlag = null
+                deriveTargetsFromDirectoriesSection = null
             )
 
             // when
@@ -114,7 +114,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = null,
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFlag = null
+                deriveTargetsFromDirectoriesSection = null
             )
 
             // when
@@ -139,7 +139,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFlag = null
+                deriveTargetsFromDirectoriesSection = null
             )
 
             // when
@@ -170,7 +170,7 @@ class DefaultProjectViewGeneratorTest {
                     )
                 ),
                 directories = null,
-                deriveTargetsFlag = null
+                deriveTargetsFromDirectoriesSection = null
             )
 
             // when
@@ -208,7 +208,7 @@ class DefaultProjectViewGeneratorTest {
                                     Path("excluded_dir2")
                             )
                     ),
-                    deriveTargetsFlag = null
+                    deriveTargetsFromDirectoriesSection = null
             )
 
             // when
@@ -229,7 +229,7 @@ class DefaultProjectViewGeneratorTest {
         }
 
         @Test
-        fun `should return pretty string only with derive_targets_from_directories for project view only with deriveTargetsFlag`() {
+        fun `should return pretty string only with derive_targets_from_directories for project view only with deriveTargetsFromDirectoriesSection`() {
             // given
             val projectView = ProjectView(
                     targets = null,
@@ -238,7 +238,7 @@ class DefaultProjectViewGeneratorTest {
                     javaPath = null,
                     buildFlags = null,
                     directories = null,
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             // when
@@ -263,7 +263,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = ProjectViewBuildFlagsSection(emptyList()),
                 directories = ProjectViewDirectoriesSection(emptyList(), emptyList()),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             // when
@@ -312,7 +312,7 @@ class DefaultProjectViewGeneratorTest {
                     )
                 ),
                 directories = null,
-                deriveTargetsFlag = null
+                deriveTargetsFromDirectoriesSection = null
             )
 
             // when
@@ -373,7 +373,7 @@ class DefaultProjectViewGeneratorTest {
                                 Path("excluded_dir2")
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             // when
@@ -456,7 +456,7 @@ class DefaultProjectViewGeneratorTest {
                                 Path("excluded_dir2")
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             // when
@@ -537,7 +537,7 @@ class DefaultProjectViewGeneratorTest {
                                 Path("excluded_dir2")
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             // when
@@ -591,7 +591,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = ProjectViewBuildFlagsSection(emptyList()),
                 directories = ProjectViewDirectoriesSection(emptyList(), emptyList()),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             val parser = DefaultProjectViewParser()
@@ -611,7 +611,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             parsedProjectViewTry.get() shouldBe expectedProjectView
         }
@@ -640,7 +640,7 @@ class DefaultProjectViewGeneratorTest {
                     )
                 ),
                 directories = null,
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             val parser = DefaultProjectViewParser()
@@ -694,7 +694,7 @@ class DefaultProjectViewGeneratorTest {
                                 Path("excluded_dir2")
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             val parser = DefaultProjectViewParser()

--- a/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/generator/DefaultProjectViewGeneratorTest.kt
+++ b/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/generator/DefaultProjectViewGeneratorTest.kt
@@ -29,7 +29,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = null,
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFromDirectoriesSection = null
+                deriveTargetsFromDirectories = null
             )
 
             // when
@@ -59,7 +59,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = null,
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFromDirectoriesSection = null
+                deriveTargetsFromDirectories = null
             )
 
             // when
@@ -89,7 +89,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = null,
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFromDirectoriesSection = null
+                deriveTargetsFromDirectories = null
             )
 
             // when
@@ -114,7 +114,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = null,
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFromDirectoriesSection = null
+                deriveTargetsFromDirectories = null
             )
 
             // when
@@ -139,7 +139,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFromDirectoriesSection = null
+                deriveTargetsFromDirectories = null
             )
 
             // when
@@ -170,7 +170,7 @@ class DefaultProjectViewGeneratorTest {
                     )
                 ),
                 directories = null,
-                deriveTargetsFromDirectoriesSection = null
+                deriveTargetsFromDirectories = null
             )
 
             // when
@@ -208,7 +208,7 @@ class DefaultProjectViewGeneratorTest {
                                     Path("excluded_dir2")
                             )
                     ),
-                    deriveTargetsFromDirectoriesSection = null
+                    deriveTargetsFromDirectories = null
             )
 
             // when
@@ -229,7 +229,7 @@ class DefaultProjectViewGeneratorTest {
         }
 
         @Test
-        fun `should return pretty string only with derive_targets_from_directories for project view only with deriveTargetsFromDirectoriesSection`() {
+        fun `should return pretty string only with derive_targets_from_directories for project view only with deriveTargetsFromDirectories`() {
             // given
             val projectView = ProjectView(
                     targets = null,
@@ -238,7 +238,7 @@ class DefaultProjectViewGeneratorTest {
                     javaPath = null,
                     buildFlags = null,
                     directories = null,
-                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                    deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             // when
@@ -263,7 +263,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = ProjectViewBuildFlagsSection(emptyList()),
                 directories = ProjectViewDirectoriesSection(emptyList(), emptyList()),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             // when
@@ -312,7 +312,7 @@ class DefaultProjectViewGeneratorTest {
                     )
                 ),
                 directories = null,
-                deriveTargetsFromDirectoriesSection = null
+                deriveTargetsFromDirectories = null
             )
 
             // when
@@ -373,7 +373,7 @@ class DefaultProjectViewGeneratorTest {
                                 Path("excluded_dir2")
                         )
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             // when
@@ -456,7 +456,7 @@ class DefaultProjectViewGeneratorTest {
                                 Path("excluded_dir2")
                         )
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             // when
@@ -537,7 +537,7 @@ class DefaultProjectViewGeneratorTest {
                                 Path("excluded_dir2")
                         )
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             // when
@@ -591,7 +591,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = ProjectViewBuildFlagsSection(emptyList()),
                 directories = ProjectViewDirectoriesSection(emptyList(), emptyList()),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             val parser = DefaultProjectViewParser()
@@ -611,7 +611,7 @@ class DefaultProjectViewGeneratorTest {
                 javaPath = ProjectViewJavaPathSection(Paths.get("/path/to/java")),
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             parsedProjectViewTry.get() shouldBe expectedProjectView
         }
@@ -640,7 +640,7 @@ class DefaultProjectViewGeneratorTest {
                     )
                 ),
                 directories = null,
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             val parser = DefaultProjectViewParser()
@@ -694,7 +694,7 @@ class DefaultProjectViewGeneratorTest {
                                 Path("excluded_dir2")
                         )
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
 
             val parser = DefaultProjectViewParser()

--- a/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/model/ProjectViewBuilderTest.kt
+++ b/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/model/ProjectViewBuilderTest.kt
@@ -101,7 +101,7 @@ class ProjectViewBuilderTest {
                             ),
                             listOf(Path("excluded_dir1"))
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             // then
@@ -130,7 +130,7 @@ class ProjectViewBuilderTest {
                         ),
                         listOf(Path("excluded_dir1"))
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -163,7 +163,7 @@ class ProjectViewBuilderTest {
                         ),
                         listOf(Path("excluded_dir1"))
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             // when
@@ -195,7 +195,7 @@ class ProjectViewBuilderTest {
                         ),
                         listOf(Path("excluded_dir1"))
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -224,7 +224,7 @@ class ProjectViewBuilderTest {
                             ),
                             listOf(Path("excluded_dir1"))
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             // then
@@ -245,7 +245,7 @@ class ProjectViewBuilderTest {
                         ),
                         listOf(Path("excluded_dir1"))
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -278,7 +278,7 @@ class ProjectViewBuilderTest {
                             ),
                             listOf(Path("excluded_dir1.1"))
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build()
 
             // when
@@ -308,7 +308,7 @@ class ProjectViewBuilderTest {
                             ),
                             listOf(Path("excluded_dir2.1"))
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build()
 
             // then
@@ -355,7 +355,7 @@ class ProjectViewBuilderTest {
                                 Path("excluded_dir2.1"),
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
             )
             projectView shouldBe expectedProjectView
         }
@@ -392,7 +392,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir1.1")
                             )
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(false)
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build()
 
             val importedProjectViewTry2 =
@@ -438,7 +438,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir3.1")
                             )
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(false)
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build()
 
             // when
@@ -467,7 +467,7 @@ class ProjectViewBuilderTest {
                                 Path("excluded_dir4.1")
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             ).build()
 
             // then
@@ -526,7 +526,7 @@ class ProjectViewBuilderTest {
                                 Path("excluded_dir4.1")
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -563,7 +563,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir1.1")
                             )
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             val importedProjectViewTry2 =
@@ -607,7 +607,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir3.1")
                             )
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             val importedProjectViewTry4 = ProjectView.Builder().build()
@@ -639,7 +639,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir4.1")
                             )
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             // then
@@ -698,7 +698,7 @@ class ProjectViewBuilderTest {
                                 Path("excluded_dir4.1")
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }

--- a/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/model/ProjectViewBuilderTest.kt
+++ b/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/model/ProjectViewBuilderTest.kt
@@ -3,16 +3,13 @@ package org.jetbrains.bsp.bazel.projectview.model
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import io.kotest.matchers.shouldBe
 import io.vavr.control.Try
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewBazelPathSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewBuildFlagsSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDebuggerAddressSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewJavaPathSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewTargetsSection
+import org.jetbrains.bsp.bazel.projectview.model.sections.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.io.IOException
 import java.nio.file.Paths
+import kotlin.io.path.Path
 
 @DisplayName("ProjectView.Builder(..) tests")
 class ProjectViewBuilderTest {
@@ -67,6 +64,8 @@ class ProjectViewBuilderTest {
                 debuggerAddress = null,
                 javaPath = null,
                 buildFlags = null,
+                directories = null,
+                deriveTargetsFlag = null
             )
             projectView shouldBe expectedProjectView
         }
@@ -95,7 +94,14 @@ class ProjectViewBuilderTest {
                     bazelPath = ProjectViewBazelPathSection(Paths.get("path/to/bazel")),
                     debuggerAddress = ProjectViewDebuggerAddressSection("127.0.0.1:8000"),
                     javaPath = ProjectViewJavaPathSection(Paths.get("path/to/java")),
-                    buildFlags = ProjectViewBuildFlagsSection(listOf("--build_flag1=value1", "--build_flag2=value2"))
+                    buildFlags = ProjectViewBuildFlagsSection(listOf("--build_flag1=value1", "--build_flag2=value2")),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir1"), Path("included_dir2")
+                            ),
+                            listOf(Path("excluded_dir1"))
+                    ),
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
                 ).build()
 
             // then
@@ -117,7 +123,14 @@ class ProjectViewBuilderTest {
                 bazelPath = ProjectViewBazelPathSection(Paths.get("path/to/bazel")),
                 debuggerAddress = ProjectViewDebuggerAddressSection("127.0.0.1:8000"),
                 javaPath = ProjectViewJavaPathSection(Paths.get("path/to/java")),
-                buildFlags = ProjectViewBuildFlagsSection(listOf("--build_flag1=value1", "--build_flag2=value2"))
+                buildFlags = ProjectViewBuildFlagsSection(listOf("--build_flag1=value1", "--build_flag2=value2")),
+                directories = ProjectViewDirectoriesSection(
+                        listOf(
+                                Path("included_dir1"), Path("included_dir2")
+                        ),
+                        listOf(Path("excluded_dir1"))
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -143,7 +156,14 @@ class ProjectViewBuilderTest {
                     javaPath = ProjectViewJavaPathSection(Paths.get("path/to/java")),
                     buildFlags = ProjectViewBuildFlagsSection(
                         listOf("--build_flag1=value1", "--build_flag2=value2")
-                    )
+                    ),
+                    directories = ProjectViewDirectoriesSection(
+                        listOf(
+                                Path("included_dir1"), Path("included_dir2")
+                        ),
+                        listOf(Path("excluded_dir1"))
+                    ),
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
                 ).build()
 
             // when
@@ -168,7 +188,14 @@ class ProjectViewBuilderTest {
                 bazelPath = ProjectViewBazelPathSection(Paths.get("path/to/bazel")),
                 debuggerAddress = ProjectViewDebuggerAddressSection("0.0.0.1:8000"),
                 javaPath = ProjectViewJavaPathSection(Paths.get("path/to/java")),
-                buildFlags = ProjectViewBuildFlagsSection(listOf("--build_flag1=value1", "--build_flag2=value2"))
+                buildFlags = ProjectViewBuildFlagsSection(listOf("--build_flag1=value1", "--build_flag2=value2")),
+                directories = ProjectViewDirectoriesSection(
+                        listOf(
+                                Path("included_dir1"), Path("included_dir2")
+                        ),
+                        listOf(Path("excluded_dir1"))
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -191,6 +218,13 @@ class ProjectViewBuilderTest {
                     buildFlags = ProjectViewBuildFlagsSection(
                         listOf("--build_flag1=value1", "--build_flag2=value2")
                     ),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir1"), Path("included_dir2")
+                            ),
+                            listOf(Path("excluded_dir1"))
+                    ),
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
                 ).build()
 
             // then
@@ -204,7 +238,14 @@ class ProjectViewBuilderTest {
                 bazelPath = ProjectViewBazelPathSection(Paths.get("path/to/bazel")),
                 debuggerAddress = ProjectViewDebuggerAddressSection("0.0.0.1:8000"),
                 javaPath = ProjectViewJavaPathSection(Paths.get("path/to/java")),
-                buildFlags = ProjectViewBuildFlagsSection(listOf("--build_flag1=value1", "--build_flag2=value2"))
+                buildFlags = ProjectViewBuildFlagsSection(listOf("--build_flag1=value1", "--build_flag2=value2")),
+                directories = ProjectViewDirectoriesSection(
+                        listOf(
+                                Path("included_dir1"), Path("included_dir2")
+                        ),
+                        listOf(Path("excluded_dir1"))
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -230,7 +271,14 @@ class ProjectViewBuilderTest {
                     javaPath = ProjectViewJavaPathSection(Paths.get("imported/path/to/java")),
                     buildFlags = ProjectViewBuildFlagsSection(
                         listOf("--build_flag1.1=value1.1", "--build_flag1.2=value1.2")
-                    )
+                    ),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir1.1"), Path("included_dir1.2")
+                            ),
+                            listOf(Path("excluded_dir1.1"))
+                    ),
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
                 ).build()
 
             // when
@@ -253,7 +301,14 @@ class ProjectViewBuilderTest {
                     javaPath = ProjectViewJavaPathSection(Paths.get("path/to/java")),
                     buildFlags = ProjectViewBuildFlagsSection(
                         listOf("--build_flag2.1=value2.1", "--build_flag2.2=value2.2")
-                    )
+                    ),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir2.1"), Path("included_dir2.2")
+                            ),
+                            listOf(Path("excluded_dir2.1"))
+                    ),
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
                 ).build()
 
             // then
@@ -287,7 +342,20 @@ class ProjectViewBuilderTest {
                         "--build_flag2.1=value2.1",
                         "--build_flag2.2=value2.2"
                     )
-                )
+                ),
+                directories = ProjectViewDirectoriesSection(
+                        listOf(
+                                Path("included_dir1.1"),
+                                Path("included_dir1.2"),
+                                Path("included_dir2.1"),
+                                Path("included_dir2.2"),
+                        ),
+                        listOf(
+                                Path("excluded_dir1.1"),
+                                Path("excluded_dir2.1"),
+                        )
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -314,7 +382,17 @@ class ProjectViewBuilderTest {
                     javaPath = ProjectViewJavaPathSection(Paths.get("imported1/path/to/java")),
                     buildFlags = ProjectViewBuildFlagsSection(
                         listOf("--build_flag1.1=value1.1", "--build_flag1.2=value1.2")
-                    )
+                    ),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir1.1"),
+                                    Path("included_dir1.2")
+                            ),
+                            listOf(
+                                    Path("excluded_dir1.1")
+                            )
+                    ),
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(false)
                 ).build()
 
             val importedProjectViewTry2 =
@@ -323,7 +401,16 @@ class ProjectViewBuilderTest {
                         listOf(BuildTargetIdentifier("//included_target2.1")),
                         listOf(BuildTargetIdentifier("//excluded_target2.1"))
                     ),
-                    buildFlags = ProjectViewBuildFlagsSection(listOf("--build_flag2.1=value2.1"))
+                    buildFlags = ProjectViewBuildFlagsSection(listOf("--build_flag2.1=value2.1")),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir2.1"),
+                                    Path("included_dir2.2")
+                            ),
+                            listOf(
+                                    Path("excluded_dir2.1")
+                            )
+                    )
                 ).build()
 
             val importedProjectViewTry3 =
@@ -341,7 +428,17 @@ class ProjectViewBuilderTest {
                     javaPath = ProjectViewJavaPathSection(Paths.get("imported3/path/to/java")),
                     buildFlags = ProjectViewBuildFlagsSection(
                         listOf("--build_flag3.1=value3.1")
-                    )
+                    ),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir3.1"),
+                                    Path("included_dir3.2")
+                            ),
+                            listOf(
+                                    Path("excluded_dir3.1")
+                            )
+                    ),
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(false)
                 ).build()
 
             // when
@@ -360,9 +457,18 @@ class ProjectViewBuilderTest {
                 ),
                 buildFlags = ProjectViewBuildFlagsSection(
                     listOf("--build_flag4.1=value4.1", "--build_flag4.2=value4.2")
-                )
-            )
-                .build()
+                ),
+                directories = ProjectViewDirectoriesSection(
+                        listOf(
+                                Path("included_dir4.1"),
+                                Path("included_dir4.2")
+                        ),
+                        listOf(
+                                Path("excluded_dir4.1")
+                        )
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+            ).build()
 
             // then
             projectViewTry.isSuccess shouldBe true
@@ -401,7 +507,26 @@ class ProjectViewBuilderTest {
                         "--build_flag4.1=value4.1",
                         "--build_flag4.2=value4.2"
                     )
-                )
+                ),
+                directories = ProjectViewDirectoriesSection(
+                        listOf(
+                                Path("included_dir1.1"),
+                                Path("included_dir1.2"),
+                                Path("included_dir2.1"),
+                                Path("included_dir2.2"),
+                                Path("included_dir3.1"),
+                                Path("included_dir3.2"),
+                                Path("included_dir4.1"),
+                                Path("included_dir4.2")
+                        ),
+                        listOf(
+                                Path("excluded_dir1.1"),
+                                Path("excluded_dir2.1"),
+                                Path("excluded_dir3.1"),
+                                Path("excluded_dir4.1")
+                        )
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -428,7 +553,17 @@ class ProjectViewBuilderTest {
                     javaPath = ProjectViewJavaPathSection(Paths.get("imported1/path/to/java")),
                     buildFlags = ProjectViewBuildFlagsSection(
                         listOf("--build_flag1.1=value1.1", "--build_flag1.2=value1.2")
-                    )
+                    ),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir1.1"),
+                                    Path("included_dir1.2")
+                            ),
+                            listOf(
+                                    Path("excluded_dir1.1")
+                            )
+                    ),
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
                 ).build()
 
             val importedProjectViewTry2 =
@@ -437,7 +572,16 @@ class ProjectViewBuilderTest {
                         listOf(BuildTargetIdentifier("//included_target2.1")),
                         listOf(BuildTargetIdentifier("//excluded_target2.1"))
                     ),
-                    buildFlags = ProjectViewBuildFlagsSection(listOf("--build_flag2.1=value2.1"))
+                    buildFlags = ProjectViewBuildFlagsSection(listOf("--build_flag2.1=value2.1")),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir2.1"),
+                                    Path("included_dir2.2")
+                            ),
+                            listOf(
+                                    Path("excluded_dir2.1")
+                            )
+                    )
                 ).build()
 
             val importedProjectViewTry3 =
@@ -454,6 +598,16 @@ class ProjectViewBuilderTest {
                     debuggerAddress = ProjectViewDebuggerAddressSection("0.0.0.3:8000"),
                     javaPath = ProjectViewJavaPathSection(Paths.get("imported3/path/to/java")),
                     buildFlags = ProjectViewBuildFlagsSection(listOf("--build_flag3.1=value3.1")),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir3.1"),
+                                    Path("included_dir3.2")
+                            ),
+                            listOf(
+                                    Path("excluded_dir3.1")
+                            )
+                    ),
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
                 ).build()
 
             val importedProjectViewTry4 = ProjectView.Builder().build()
@@ -475,7 +629,17 @@ class ProjectViewBuilderTest {
                     ),
                     buildFlags = ProjectViewBuildFlagsSection(
                         listOf("--build_flag4.1=value4.1", "--build_flag4.2=value4.2")
-                    )
+                    ),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir4.1"),
+                                    Path("included_dir4.2")
+                            ),
+                            listOf(
+                                    Path("excluded_dir4.1")
+                            )
+                    ),
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
                 ).build()
 
             // then
@@ -515,7 +679,26 @@ class ProjectViewBuilderTest {
                         "--build_flag4.1=value4.1",
                         "--build_flag4.2=value4.2"
                     )
-                )
+                ),
+                directories = ProjectViewDirectoriesSection(
+                        listOf(
+                                Path("included_dir1.1"),
+                                Path("included_dir1.2"),
+                                Path("included_dir2.1"),
+                                Path("included_dir2.2"),
+                                Path("included_dir3.1"),
+                                Path("included_dir3.2"),
+                                Path("included_dir4.1"),
+                                Path("included_dir4.2")
+                        ),
+                        listOf(
+                                Path("excluded_dir1.1"),
+                                Path("excluded_dir2.1"),
+                                Path("excluded_dir3.1"),
+                                Path("excluded_dir4.1")
+                        )
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
             )
             projectView shouldBe expectedProjectView
         }

--- a/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/model/ProjectViewBuilderTest.kt
+++ b/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/model/ProjectViewBuilderTest.kt
@@ -65,7 +65,7 @@ class ProjectViewBuilderTest {
                 javaPath = null,
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFlag = null
+                deriveTargetsFromDirectoriesSection = null
             )
             projectView shouldBe expectedProjectView
         }
@@ -101,7 +101,7 @@ class ProjectViewBuilderTest {
                             ),
                             listOf(Path("excluded_dir1"))
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             // then
@@ -130,7 +130,7 @@ class ProjectViewBuilderTest {
                         ),
                         listOf(Path("excluded_dir1"))
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -163,7 +163,7 @@ class ProjectViewBuilderTest {
                         ),
                         listOf(Path("excluded_dir1"))
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             // when
@@ -195,7 +195,7 @@ class ProjectViewBuilderTest {
                         ),
                         listOf(Path("excluded_dir1"))
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -224,7 +224,7 @@ class ProjectViewBuilderTest {
                             ),
                             listOf(Path("excluded_dir1"))
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             // then
@@ -245,7 +245,7 @@ class ProjectViewBuilderTest {
                         ),
                         listOf(Path("excluded_dir1"))
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -278,7 +278,7 @@ class ProjectViewBuilderTest {
                             ),
                             listOf(Path("excluded_dir1.1"))
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build()
 
             // when
@@ -308,7 +308,7 @@ class ProjectViewBuilderTest {
                             ),
                             listOf(Path("excluded_dir2.1"))
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build()
 
             // then
@@ -355,7 +355,7 @@ class ProjectViewBuilderTest {
                                 Path("excluded_dir2.1"),
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
             )
             projectView shouldBe expectedProjectView
         }
@@ -392,7 +392,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir1.1")
                             )
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build()
 
             val importedProjectViewTry2 =
@@ -438,7 +438,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir3.1")
                             )
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build()
 
             // when
@@ -467,7 +467,7 @@ class ProjectViewBuilderTest {
                                 Path("excluded_dir4.1")
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             ).build()
 
             // then
@@ -526,7 +526,7 @@ class ProjectViewBuilderTest {
                                 Path("excluded_dir4.1")
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -563,7 +563,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir1.1")
                             )
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             val importedProjectViewTry2 =
@@ -607,7 +607,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir3.1")
                             )
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             val importedProjectViewTry4 = ProjectView.Builder().build()
@@ -639,7 +639,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir4.1")
                             )
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             // then
@@ -698,7 +698,7 @@ class ProjectViewBuilderTest {
                                 Path("excluded_dir4.1")
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }

--- a/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/model/ProjectViewBuilderTest.kt
+++ b/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/model/ProjectViewBuilderTest.kt
@@ -65,7 +65,7 @@ class ProjectViewBuilderTest {
                 javaPath = null,
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFromDirectoriesSection = null
+                deriveTargetsFromDirectories = null
             )
             projectView shouldBe expectedProjectView
         }
@@ -101,7 +101,7 @@ class ProjectViewBuilderTest {
                             ),
                             listOf(Path("excluded_dir1"))
                     ),
-                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                    deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             // then
@@ -130,7 +130,7 @@ class ProjectViewBuilderTest {
                         ),
                         listOf(Path("excluded_dir1"))
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -163,7 +163,7 @@ class ProjectViewBuilderTest {
                         ),
                         listOf(Path("excluded_dir1"))
                     ),
-                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                    deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             // when
@@ -195,7 +195,7 @@ class ProjectViewBuilderTest {
                         ),
                         listOf(Path("excluded_dir1"))
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -224,7 +224,7 @@ class ProjectViewBuilderTest {
                             ),
                             listOf(Path("excluded_dir1"))
                     ),
-                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                    deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             // then
@@ -245,7 +245,7 @@ class ProjectViewBuilderTest {
                         ),
                         listOf(Path("excluded_dir1"))
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -278,7 +278,7 @@ class ProjectViewBuilderTest {
                             ),
                             listOf(Path("excluded_dir1.1"))
                     ),
-                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                    deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build()
 
             // when
@@ -308,7 +308,7 @@ class ProjectViewBuilderTest {
                             ),
                             listOf(Path("excluded_dir2.1"))
                     ),
-                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                    deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build()
 
             // then
@@ -355,7 +355,7 @@ class ProjectViewBuilderTest {
                                 Path("excluded_dir2.1"),
                         )
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(false)
             )
             projectView shouldBe expectedProjectView
         }
@@ -392,7 +392,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir1.1")
                             )
                     ),
-                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                    deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build()
 
             val importedProjectViewTry2 =
@@ -438,7 +438,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir3.1")
                             )
                     ),
-                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                    deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build()
 
             // when
@@ -467,7 +467,7 @@ class ProjectViewBuilderTest {
                                 Path("excluded_dir4.1")
                         )
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             ).build()
 
             // then
@@ -526,7 +526,7 @@ class ProjectViewBuilderTest {
                                 Path("excluded_dir4.1")
                         )
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -563,7 +563,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir1.1")
                             )
                     ),
-                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                    deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             val importedProjectViewTry2 =
@@ -607,7 +607,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir3.1")
                             )
                     ),
-                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                    deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             val importedProjectViewTry4 = ProjectView.Builder().build()
@@ -639,7 +639,7 @@ class ProjectViewBuilderTest {
                                     Path("excluded_dir4.1")
                             )
                     ),
-                    deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                    deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build()
 
             // then
@@ -698,7 +698,7 @@ class ProjectViewBuilderTest {
                                 Path("excluded_dir4.1")
                         )
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }

--- a/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParserTest.kt
+++ b/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParserTest.kt
@@ -155,7 +155,7 @@ class DefaultProjectViewParserTest {
             projectViewTry.isSuccess shouldBe true
             val projectView = projectViewTry.get()
 
-            projectView.deriveTargetsFromDirectoriesSection shouldBe null
+            projectView.deriveTargetsFromDirectories shouldBe null
         }
 
         @Test
@@ -177,7 +177,7 @@ class DefaultProjectViewParserTest {
                 javaPath = null,
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFromDirectoriesSection = null
+                deriveTargetsFromDirectories = null
             )
 
             projectView shouldBe expectedProjectView
@@ -222,7 +222,7 @@ class DefaultProjectViewParserTest {
                         Path("excluded_dir1.1")
                     )
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -275,7 +275,7 @@ class DefaultProjectViewParserTest {
                             Path("excluded_dir4.1")
                         )
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -326,7 +326,7 @@ class DefaultProjectViewParserTest {
                             Path("excluded_dir1.1")
                         )
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(false)
             )
             projectView shouldBe expectedProjectView
         }
@@ -368,7 +368,7 @@ class DefaultProjectViewParserTest {
                         Path("excluded_dir8.1"),
                     )
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -426,7 +426,7 @@ class DefaultProjectViewParserTest {
                             Path("excluded_dir3.1"),
                         )
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(false)
             )
             projectView shouldBe expectedProjectView
         }
@@ -489,7 +489,7 @@ class DefaultProjectViewParserTest {
                         Path("excluded_dir4.1"),
                     )
                 ),
-                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }

--- a/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParserTest.kt
+++ b/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParserTest.kt
@@ -155,7 +155,7 @@ class DefaultProjectViewParserTest {
             projectViewTry.isSuccess shouldBe true
             val projectView = projectViewTry.get()
 
-            projectView.deriveTargetsFlag shouldBe null
+            projectView.deriveTargetsFromDirectoriesSection shouldBe null
         }
 
         @Test
@@ -177,7 +177,7 @@ class DefaultProjectViewParserTest {
                 javaPath = null,
                 buildFlags = null,
                 directories = null,
-                deriveTargetsFlag = null
+                deriveTargetsFromDirectoriesSection = null
             )
 
             projectView shouldBe expectedProjectView
@@ -198,8 +198,12 @@ class DefaultProjectViewParserTest {
             val expectedProjectView = ProjectView(
                 targets = ProjectViewTargetsSection(
                     listOf(
-                        BuildTargetIdentifier("//included_target1.1"), BuildTargetIdentifier("//included_target1.2")
-                    ), listOf(BuildTargetIdentifier("//excluded_target1.1"))
+                        BuildTargetIdentifier("//included_target1.1"),
+                        BuildTargetIdentifier("//included_target1.2")
+                    ),
+                    listOf(
+                        BuildTargetIdentifier("//excluded_target1.1")
+                    )
                 ),
                 bazelPath = ProjectViewBazelPathSection(Path("path1/to/bazel")),
                 debuggerAddress = ProjectViewDebuggerAddressSection("0.0.0.1:8000"),
@@ -211,14 +215,14 @@ class DefaultProjectViewParserTest {
                 ),
                 directories = ProjectViewDirectoriesSection(
                     listOf(
-                        Path("included_dir1"),
-                        Path("included_dir2")
+                        Path("included_dir1.1"),
+                        Path("included_dir1.2")
                     ),
                     listOf(
-                        Path("excluded_dir1")
+                        Path("excluded_dir1.1")
                     )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -261,17 +265,17 @@ class DefaultProjectViewParserTest {
                 ),
                 directories = ProjectViewDirectoriesSection(
                         listOf(
-                            Path("included_dir1"),
-                            Path("included_dir2"),
+                            Path("included_dir1.1"),
+                            Path("included_dir1.2"),
                             Path("included_dir4.1"),
                             Path("included_dir4.2")
                         ),
                         listOf(
-                            Path("excluded_dir1"),
+                            Path("excluded_dir1.1"),
                             Path("excluded_dir4.1")
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -315,14 +319,14 @@ class DefaultProjectViewParserTest {
                 ),
                 directories = ProjectViewDirectoriesSection(
                         listOf(
-                            Path("included_dir1"),
-                            Path("included_dir2")
+                            Path("included_dir1.1"),
+                            Path("included_dir1.2")
                         ),
                         listOf(
-                            Path("excluded_dir1")
+                            Path("excluded_dir1.1")
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
             )
             projectView shouldBe expectedProjectView
         }
@@ -357,14 +361,14 @@ class DefaultProjectViewParserTest {
                 ),
                 directories = ProjectViewDirectoriesSection(
                     listOf(
-                        Path("included_dir1"),
-                        Path("included_dir2")
+                        Path("included_dir8.1"),
+                        Path("included_dir8.2")
                     ),
                     listOf(
-                        Path("excluded_dir1"),
+                        Path("excluded_dir8.1"),
                     )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -411,18 +415,18 @@ class DefaultProjectViewParserTest {
                 ),
                 directories = ProjectViewDirectoriesSection(
                         listOf(
-                            Path("included_dir1"),
-                            Path("included_dir2"),
+                            Path("included_dir1.1"),
+                            Path("included_dir1.2"),
                             Path("included_dir2.1"),
                             Path("included_dir3.1")
                         ),
                         listOf(
-                            Path("excluded_dir1"),
+                            Path("excluded_dir1.1"),
                             Path("excluded_dir2.1"),
                             Path("excluded_dir3.1"),
                         )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
             )
             projectView shouldBe expectedProjectView
         }
@@ -473,19 +477,19 @@ class DefaultProjectViewParserTest {
                     listOf(
                         Path("included_dir2.1"),
                         Path("included_dir3.1"),
-                        Path("included_dir1"),
-                        Path("included_dir2"),
+                        Path("included_dir1.1"),
+                        Path("included_dir1.2"),
                         Path("included_dir4.1"),
                         Path("included_dir4.2")
                     ),
                     listOf(
                         Path("excluded_dir2.1"),
                         Path("excluded_dir3.1"),
-                        Path("excluded_dir1"),
+                        Path("excluded_dir1.1"),
                         Path("excluded_dir4.1"),
                     )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }

--- a/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParserTest.kt
+++ b/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParserTest.kt
@@ -3,11 +3,7 @@ package org.jetbrains.bsp.bazel.projectview.parser
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import io.kotest.matchers.shouldBe
 import org.jetbrains.bsp.bazel.projectview.model.ProjectView
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewBazelPathSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewBuildFlagsSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDebuggerAddressSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewJavaPathSection
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewTargetsSection
+import org.jetbrains.bsp.bazel.projectview.model.sections.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -133,6 +129,36 @@ class DefaultProjectViewParserTest {
         }
 
         @Test
+        fun `should return empty directories section for file without directories section`() {
+            // given
+            val projectViewFilePath = Path("/projectview/without/javapath.bazelproject")
+
+            // when
+            val projectViewTry = parser.parse(projectViewFilePath)
+
+            // then
+            projectViewTry.isSuccess shouldBe true
+            val projectView = projectViewTry.get()
+
+            projectView.directories shouldBe null
+        }
+
+        @Test
+        fun `should return empty derive_targets_from_directories section for file without derive_targets_from_directories section`() {
+            // given
+            val projectViewFilePath = Path("/projectview/without/javapath.bazelproject")
+
+            // when
+            val projectViewTry = parser.parse(projectViewFilePath)
+
+            // then
+            projectViewTry.isSuccess shouldBe true
+            val projectView = projectViewTry.get()
+
+            projectView.deriveTargetsFlag shouldBe null
+        }
+
+        @Test
         fun `should parse empty file`() {
             // given
             val projectViewFilePath = Path("/projectview/empty.bazelproject")
@@ -150,6 +176,8 @@ class DefaultProjectViewParserTest {
                 debuggerAddress = null,
                 javaPath = null,
                 buildFlags = null,
+                directories = null,
+                deriveTargetsFlag = null
             )
 
             projectView shouldBe expectedProjectView
@@ -180,7 +208,14 @@ class DefaultProjectViewParserTest {
                     listOf(
                         "--build_flag1.1=value1.1", "--build_flag1.2=value1.2"
                     )
-                )
+                ),
+                directories = ProjectViewDirectoriesSection(
+                    listOf(
+                          Path("included_dir1"), Path("included_dir2")
+                    ),
+                    listOf(Path("excluded_dir1"))
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -220,7 +255,14 @@ class DefaultProjectViewParserTest {
                         "--build_flag4.2=value4.2",
                         "--build_flag4.3=value4.3",
                     )
-                )
+                ),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir1"), Path("included_dir2")
+                            ),
+                            listOf(Path("excluded_dir1"))
+                    ),
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -261,7 +303,14 @@ class DefaultProjectViewParserTest {
                         "--build_flag7.2=value7.2",
                         "--build_flag7.3=value7.3",
                     )
-                )
+                ),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir1"), Path("included_dir2")
+                            ),
+                            listOf(Path("excluded_dir1"))
+                    ),
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -293,7 +342,9 @@ class DefaultProjectViewParserTest {
                         "--build_flag8.2=value8.2",
                         "--build_flag8.3=value8.3",
                     )
-                )
+                ),
+                    directories = null,
+                    deriveTargetsFlag = null
             )
             projectView shouldBe expectedProjectView
         }
@@ -337,7 +388,14 @@ class DefaultProjectViewParserTest {
                         "--build_flag5.1=value5.1",
                         "--build_flag5.2=value5.2",
                     )
-                )
+                ),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir1"), Path("included_dir2")
+                            ),
+                            listOf(Path("excluded_dir1"))
+                    ),
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -383,7 +441,14 @@ class DefaultProjectViewParserTest {
                         "--build_flag4.2=value4.2",
                         "--build_flag4.3=value4.3",
                     )
-                )
+                ),
+                    directories = ProjectViewDirectoriesSection(
+                            listOf(
+                                    Path("included_dir1"), Path("included_dir2")
+                            ),
+                            listOf(Path("excluded_dir1"))
+                    ),
+                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
             )
             projectView shouldBe expectedProjectView
         }

--- a/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParserTest.kt
+++ b/executioncontext/projectview/src/test/java/org/jetbrains/bsp/bazel/projectview/parser/DefaultProjectViewParserTest.kt
@@ -131,7 +131,7 @@ class DefaultProjectViewParserTest {
         @Test
         fun `should return empty directories section for file without directories section`() {
             // given
-            val projectViewFilePath = Path("/projectview/without/javapath.bazelproject")
+            val projectViewFilePath = Path("/projectview/without/directories.bazelproject")
 
             // when
             val projectViewTry = parser.parse(projectViewFilePath)
@@ -146,7 +146,7 @@ class DefaultProjectViewParserTest {
         @Test
         fun `should return empty derive_targets_from_directories section for file without derive_targets_from_directories section`() {
             // given
-            val projectViewFilePath = Path("/projectview/without/javapath.bazelproject")
+            val projectViewFilePath = Path("/projectview/without/derive_targets_from_directories.bazelproject")
 
             // when
             val projectViewTry = parser.parse(projectViewFilePath)
@@ -211,11 +211,14 @@ class DefaultProjectViewParserTest {
                 ),
                 directories = ProjectViewDirectoriesSection(
                     listOf(
-                          Path("included_dir1"), Path("included_dir2")
+                        Path("included_dir1"),
+                        Path("included_dir2")
                     ),
-                    listOf(Path("excluded_dir1"))
+                    listOf(
+                        Path("excluded_dir1")
+                    )
                 ),
-                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -256,13 +259,19 @@ class DefaultProjectViewParserTest {
                         "--build_flag4.3=value4.3",
                     )
                 ),
-                    directories = ProjectViewDirectoriesSection(
-                            listOf(
-                                    Path("included_dir1"), Path("included_dir2")
-                            ),
-                            listOf(Path("excluded_dir1"))
-                    ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                directories = ProjectViewDirectoriesSection(
+                        listOf(
+                            Path("included_dir1"),
+                            Path("included_dir2"),
+                            Path("included_dir4.1"),
+                            Path("included_dir4.2")
+                        ),
+                        listOf(
+                            Path("excluded_dir1"),
+                            Path("excluded_dir4.1")
+                        )
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -304,13 +313,16 @@ class DefaultProjectViewParserTest {
                         "--build_flag7.3=value7.3",
                     )
                 ),
-                    directories = ProjectViewDirectoriesSection(
-                            listOf(
-                                    Path("included_dir1"), Path("included_dir2")
-                            ),
-                            listOf(Path("excluded_dir1"))
-                    ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                directories = ProjectViewDirectoriesSection(
+                        listOf(
+                            Path("included_dir1"),
+                            Path("included_dir2")
+                        ),
+                        listOf(
+                            Path("excluded_dir1")
+                        )
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
             )
             projectView shouldBe expectedProjectView
         }
@@ -343,8 +355,16 @@ class DefaultProjectViewParserTest {
                         "--build_flag8.3=value8.3",
                     )
                 ),
-                    directories = null,
-                    deriveTargetsFlag = null
+                directories = ProjectViewDirectoriesSection(
+                    listOf(
+                        Path("included_dir1"),
+                        Path("included_dir2")
+                    ),
+                    listOf(
+                        Path("excluded_dir1"),
+                    )
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }
@@ -389,13 +409,20 @@ class DefaultProjectViewParserTest {
                         "--build_flag5.2=value5.2",
                     )
                 ),
-                    directories = ProjectViewDirectoriesSection(
-                            listOf(
-                                    Path("included_dir1"), Path("included_dir2")
-                            ),
-                            listOf(Path("excluded_dir1"))
-                    ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                directories = ProjectViewDirectoriesSection(
+                        listOf(
+                            Path("included_dir1"),
+                            Path("included_dir2"),
+                            Path("included_dir2.1"),
+                            Path("included_dir3.1")
+                        ),
+                        listOf(
+                            Path("excluded_dir1"),
+                            Path("excluded_dir2.1"),
+                            Path("excluded_dir3.1"),
+                        )
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
             )
             projectView shouldBe expectedProjectView
         }
@@ -442,13 +469,23 @@ class DefaultProjectViewParserTest {
                         "--build_flag4.3=value4.3",
                     )
                 ),
-                    directories = ProjectViewDirectoriesSection(
-                            listOf(
-                                    Path("included_dir1"), Path("included_dir2")
-                            ),
-                            listOf(Path("excluded_dir1"))
+                directories = ProjectViewDirectoriesSection(
+                    listOf(
+                        Path("included_dir2.1"),
+                        Path("included_dir3.1"),
+                        Path("included_dir1"),
+                        Path("included_dir2"),
+                        Path("included_dir4.1"),
+                        Path("included_dir4.2")
                     ),
-                    deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                    listOf(
+                        Path("excluded_dir2.1"),
+                        Path("excluded_dir3.1"),
+                        Path("excluded_dir1"),
+                        Path("excluded_dir4.1"),
+                    )
+                ),
+                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
             )
             projectView shouldBe expectedProjectView
         }

--- a/executioncontext/projectview/src/test/resources/projectview/file1.bazelproject
+++ b/executioncontext/projectview/src/test/resources/projectview/file1.bazelproject
@@ -25,8 +25,8 @@ build_flags:
     --build_flag1.2=value1.2
 
 directories:
-  included_dir1
-  included_dir2
-  -excluded_dir1
+    included_dir1
+    included_dir2
+    -excluded_dir1
 
 derive_targets_from_directories: true

--- a/executioncontext/projectview/src/test/resources/projectview/file1.bazelproject
+++ b/executioncontext/projectview/src/test/resources/projectview/file1.bazelproject
@@ -23,3 +23,10 @@ build_flags:
     --build_flag1.1=value1.1
     # --legacy_build_flag=old_value
     --build_flag1.2=value1.2
+
+directories:
+  included_dir1
+  included_dir2
+  -excluded_dir1
+
+derive_targets_from_directories: true

--- a/executioncontext/projectview/src/test/resources/projectview/file1.bazelproject
+++ b/executioncontext/projectview/src/test/resources/projectview/file1.bazelproject
@@ -25,8 +25,8 @@ build_flags:
     --build_flag1.2=value1.2
 
 directories:
-    included_dir1
-    included_dir2
-    -excluded_dir1
+    included_dir1.1
+    included_dir1.2
+    -excluded_dir1.1
 
 derive_targets_from_directories: true

--- a/executioncontext/projectview/src/test/resources/projectview/file2.bazelproject
+++ b/executioncontext/projectview/src/test/resources/projectview/file2.bazelproject
@@ -5,3 +5,7 @@ targets:
 build_flags:
     --build_flag2.1=value2.1
     --build_flag2.2=value2.2
+
+directories:
+    included_dir2.1
+    -excluded_dir2.1

--- a/executioncontext/projectview/src/test/resources/projectview/file3.bazelproject
+++ b/executioncontext/projectview/src/test/resources/projectview/file3.bazelproject
@@ -14,3 +14,11 @@ build_flags:
 
 
     --build_flag3.1=value3.1
+
+directories:
+
+    included_dir3.1
+
+    -excluded_dir3.1
+
+derive_targets_from_directories: false

--- a/executioncontext/projectview/src/test/resources/projectview/file4ImportsFile1.bazelproject
+++ b/executioncontext/projectview/src/test/resources/projectview/file4ImportsFile1.bazelproject
@@ -9,3 +9,8 @@ build_flags:
     --build_flag4.1=value4.1
     --build_flag4.2=value4.2
     --build_flag4.3=value4.3
+
+directories:
+    included_dir4.1
+    included_dir4.2
+    -excluded_dir4.1

--- a/executioncontext/projectview/src/test/resources/projectview/file7ImportsFile1.bazelproject
+++ b/executioncontext/projectview/src/test/resources/projectview/file7ImportsFile1.bazelproject
@@ -15,3 +15,5 @@ build_flags:
     --build_flag7.1=value7.1
     --build_flag7.2=value7.2
     --build_flag7.3=value7.3
+
+derive_targets_from_directories: false

--- a/executioncontext/projectview/src/test/resources/projectview/file8ImportsEmpty.bazelproject
+++ b/executioncontext/projectview/src/test/resources/projectview/file8ImportsEmpty.bazelproject
@@ -18,8 +18,8 @@ build_flags:
     --build_flag8.3=value8.3
 
 directories:
-    included_dir1
-    included_dir2
-    -excluded_dir1
+    included_dir8.1
+    included_dir8.2
+    -excluded_dir8.1
 
 derive_targets_from_directories: true

--- a/executioncontext/projectview/src/test/resources/projectview/file8ImportsEmpty.bazelproject
+++ b/executioncontext/projectview/src/test/resources/projectview/file8ImportsEmpty.bazelproject
@@ -16,3 +16,10 @@ build_flags:
     --build_flag8.1=value8.1
     --build_flag8.2=value8.2
     --build_flag8.3=value8.3
+
+directories:
+    included_dir1
+    included_dir2
+    -excluded_dir1
+
+derive_targets_from_directories: true

--- a/executioncontext/projectview/src/test/resources/projectview/without/derive_targets_from_directories.bazelproject
+++ b/executioncontext/projectview/src/test/resources/projectview/without/derive_targets_from_directories.bazelproject
@@ -1,0 +1,19 @@
+not_parsed_section1:
+    not_parsed1.1
+    not_parsed2.2
+
+not_parsed_section2: not_parsed2.1
+
+bazel_path: path/to/bazel
+
+debugger_address: 127.0.0.1:8000
+
+java_path: path/to/java
+
+build_flags:
+    --build_flag1.1=value1.1
+    --build_flag1.2=value1.2
+
+directories:
+  included_dir1
+  -excluded_dir1

--- a/executioncontext/projectview/src/test/resources/projectview/without/directories.bazelproject
+++ b/executioncontext/projectview/src/test/resources/projectview/without/directories.bazelproject
@@ -1,0 +1,17 @@
+not_parsed_section1:
+    not_parsed1.1
+    not_parsed2.2
+
+not_parsed_section2: not_parsed2.1
+
+bazel_path: path/to/bazel
+
+debugger_address: 127.0.0.1:8000
+
+java_path: path/to/java
+
+build_flags:
+    --build_flag1.1=value1.1
+    --build_flag1.2=value1.2
+
+derive_targets_from_directories: true

--- a/executioncontext/workspacecontext/src/main/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpec.kt
+++ b/executioncontext/workspacecontext/src/main/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpec.kt
@@ -26,15 +26,15 @@ internal object TargetsSpecMapper : ProjectViewToExecutionContextEntityMapper<Ta
     private const val NAME = "targets"
 
     override fun map(projectView: ProjectView): Try<TargetsSpec> =
-        if (projectView.deriveTargetsFlag?.value == true)
-            deriveTargetsFlagTrue(projectView)
+        if (projectView.deriveTargetsFromDirectoriesSection?.value == true)
+            deriveTargetsFromDirectoriesSectionTrue(projectView)
         else
-            deriveTargetsFlagFalse(projectView)
+            deriveTargetsFromDirectoriesSectionFalse(projectView)
 
-    private fun deriveTargetsFlagTrue(projectView: ProjectView): Try<TargetsSpec> =
+    private fun deriveTargetsFromDirectoriesSectionTrue(projectView: ProjectView): Try<TargetsSpec> =
         when {
-            projectView.directories == null -> deriveTargetsFlagFalse(projectView)
-            hasEmptyIncludedValuesAndEmptyExcludedValuesDirectories(projectView.directories!!) -> deriveTargetsFlagFalse(projectView)
+            projectView.directories == null -> deriveTargetsFromDirectoriesSectionFalse(projectView)
+            hasEmptyIncludedValuesAndEmptyExcludedValuesDirectories(projectView.directories!!) -> deriveTargetsFromDirectoriesSectionFalse(projectView)
             hasEmptyIncludedValuesAndNonEmptyExcludedValuesDirectories(projectView.directories!!) -> Try.failure(
                 ProjectViewToExecutionContextEntityMapperException(
                     NAME, "'directories' section has no included targets."
@@ -43,7 +43,7 @@ internal object TargetsSpecMapper : ProjectViewToExecutionContextEntityMapper<Ta
             else -> Try.success(mapNotEmptyDerivedTargetSection(projectView.targets, projectView.directories!!))
         }
 
-    private fun deriveTargetsFlagFalse(projectView: ProjectView): Try<TargetsSpec> =
+    private fun deriveTargetsFromDirectoriesSectionFalse(projectView: ProjectView): Try<TargetsSpec> =
         when {
             projectView.targets == null -> Try.success(defaultTargetsSpec)
             hasEmptyIncludedValuesAndEmptyExcludedValues(projectView.targets!!) -> Try.success(defaultTargetsSpec)

--- a/executioncontext/workspacecontext/src/main/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpec.kt
+++ b/executioncontext/workspacecontext/src/main/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpec.kt
@@ -6,6 +6,8 @@ import org.jetbrains.bsp.bazel.executioncontext.api.ExecutionContextExcludableLi
 import org.jetbrains.bsp.bazel.executioncontext.api.ProjectViewToExecutionContextEntityMapper
 import org.jetbrains.bsp.bazel.executioncontext.api.ProjectViewToExecutionContextEntityMapperException
 import org.jetbrains.bsp.bazel.projectview.model.ProjectView
+import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDeriveTargetsFlagSection
+import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDirectoriesSection
 import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewTargetsSection
 
 data class TargetsSpec(
@@ -23,15 +25,33 @@ internal object TargetsSpecMapper : ProjectViewToExecutionContextEntityMapper<Ta
     private const val NAME = "targets"
 
     override fun map(projectView: ProjectView): Try<TargetsSpec> =
+            if (deriveTargetsFlags(projectView.deriveTargetsFlag!!))
+                deriveTargetsFlagTrue(projectView)
+            else
+                deriveTargetsFlagFalse(projectView)
+
+    private fun deriveTargetsFlagTrue(projectView: ProjectView): Try<TargetsSpec> =
+        when {
+            projectView.directories == null -> deriveTargetsFlagFalse(projectView)
+            hasEmptyIncludedValuesAndEmptyExcludedValuesDirectories(projectView.directories!!) -> deriveTargetsFlagFalse(projectView)
+            hasEmptyIncludedValuesAndNonEmptyExcludedValuesDirectories(projectView.directories!!) -> Try.failure(
+                ProjectViewToExecutionContextEntityMapperException(
+                    NAME, "'directories' sections have no included targets."
+                )
+            )
+            else -> Try.success(mapNotEmptyDerivedTargetSection(projectView.targets, projectView.directories!!))
+        }
+
+    private fun deriveTargetsFlagFalse(projectView: ProjectView): Try<TargetsSpec> =
         when {
             projectView.targets == null -> Try.success(defaultTargetsSpec)
             hasEmptyIncludedValuesAndEmptyExcludedValues(projectView.targets!!) -> Try.success(defaultTargetsSpec)
             hasEmptyIncludedValuesAndNonEmptyExcludedValues(projectView.targets!!) -> Try.failure(
-                ProjectViewToExecutionContextEntityMapperException(
-                    NAME, "'targets' section has no included targets."
-                )
+                    ProjectViewToExecutionContextEntityMapperException(
+                            NAME, "'targets' section has no included targets."
+                    )
             )
-            else -> Try.success(mapNotEmptySection(projectView.targets!!))
+            else -> Try.success(mapNotEmptyNotDerivedTargetsSection(projectView.targets!!))
         }
 
     private fun hasEmptyIncludedValuesAndEmptyExcludedValues(targetsSection: ProjectViewTargetsSection): Boolean =
@@ -39,8 +59,28 @@ internal object TargetsSpecMapper : ProjectViewToExecutionContextEntityMapper<Ta
     private fun hasEmptyIncludedValuesAndNonEmptyExcludedValues(targetsSection: ProjectViewTargetsSection): Boolean =
         targetsSection.values.isEmpty() and targetsSection.excludedValues.isNotEmpty()
 
-    private fun mapNotEmptySection(targetsSection: ProjectViewTargetsSection): TargetsSpec =
+    private fun hasEmptyIncludedValuesAndEmptyExcludedValuesDirectories(directoriesSection: ProjectViewDirectoriesSection): Boolean =
+        directoriesSection.values.isEmpty() and directoriesSection.excludedValues.isEmpty()
+    private fun hasEmptyIncludedValuesAndNonEmptyExcludedValuesDirectories(directoriesSection: ProjectViewDirectoriesSection): Boolean =
+        directoriesSection.values.isEmpty() and directoriesSection.excludedValues.isNotEmpty()
+
+    private fun deriveTargetsFlags(deriveTargetsFlagSection: ProjectViewDeriveTargetsFlagSection): Boolean =
+        deriveTargetsFlagSection.value
+
+    private fun mapNotEmptyNotDerivedTargetsSection(targetsSection: ProjectViewTargetsSection): TargetsSpec =
         TargetsSpec(targetsSection.values, targetsSection.excludedValues)
+
+    private fun mapNotEmptyDerivedTargetSection(targetsSection: ProjectViewTargetsSection?, directoriesSection: ProjectViewDirectoriesSection): TargetsSpec {
+        val directoriesValues = directoriesSection.values.map { mapDirectoryToTarget(it) }
+        val directoriesExcludedValues = directoriesSection.excludedValues.map { mapDirectoryToTarget(it) }
+
+        return TargetsSpec(
+                (targetsSection?.values ?: emptyList()) + directoriesValues,
+                (targetsSection?.excludedValues ?: emptyList()) + directoriesExcludedValues)
+    }
+
+    private fun mapDirectoryToTarget(buildDirectoryIdentifier: BuildTargetIdentifier): BuildTargetIdentifier =
+            BuildTargetIdentifier("//" + buildDirectoryIdentifier.uri + "/...")
 
     override fun default(): Try<TargetsSpec> = Try.success(defaultTargetsSpec)
 }

--- a/executioncontext/workspacecontext/src/main/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpec.kt
+++ b/executioncontext/workspacecontext/src/main/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpec.kt
@@ -26,7 +26,7 @@ internal object TargetsSpecMapper : ProjectViewToExecutionContextEntityMapper<Ta
     private const val NAME = "targets"
 
     override fun map(projectView: ProjectView): Try<TargetsSpec> =
-        if (projectView.deriveTargetsFromDirectoriesSection?.value == true)
+        if (projectView.deriveTargetsFromDirectories?.value == true)
             deriveTargetsFromDirectoriesSectionTrue(projectView)
         else
             deriveTargetsFromDirectoriesSectionFalse(projectView)

--- a/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/BazelPathSpecMapperTest.kt
+++ b/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/BazelPathSpecMapperTest.kt
@@ -42,7 +42,7 @@ class BazelPathSpecMapperTest {
             bazelPathSpecTry.isSuccess shouldBe true
             val bazelPathSpec = bazelPathSpecTry.get()
 
-            val expectedBazelPathSpec = BazelPathSpec(Path("/usr/local/bin/bazel"))
+            val expectedBazelPathSpec = BazelPathSpec(Path("/opt/twitter_mde/bin/bazel"))
             bazelPathSpec shouldBe expectedBazelPathSpec
         }
 
@@ -80,7 +80,7 @@ class BazelPathSpecMapperTest {
             bazelPathSpecTry.isSuccess shouldBe true
             val bazelPathSpec = bazelPathSpecTry.get()
 
-            val expectedBazelPathSpec = BazelPathSpec(Path("/usr/local/bin/bazel"))
+            val expectedBazelPathSpec = BazelPathSpec(Path("/opt/twitter_mde/bin/bazel"))
             bazelPathSpec shouldBe expectedBazelPathSpec
         }
     }

--- a/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/BazelPathSpecMapperTest.kt
+++ b/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/BazelPathSpecMapperTest.kt
@@ -80,7 +80,7 @@ class BazelPathSpecMapperTest {
             bazelPathSpecTry.isSuccess shouldBe true
             val bazelPathSpec = bazelPathSpecTry.get()
 
-            val expectedBazelPathSpec = BazelPathSpec(Path("/opt/twitter_mde/bin/bazel"))
+            val expectedBazelPathSpec = BazelPathSpec(Path("/usr/local/bin/bazel"))
             bazelPathSpec shouldBe expectedBazelPathSpec
         }
     }

--- a/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/BazelPathSpecMapperTest.kt
+++ b/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/BazelPathSpecMapperTest.kt
@@ -42,7 +42,7 @@ class BazelPathSpecMapperTest {
             bazelPathSpecTry.isSuccess shouldBe true
             val bazelPathSpec = bazelPathSpecTry.get()
 
-            val expectedBazelPathSpec = BazelPathSpec(Path("/opt/twitter_mde/bin/bazel"))
+            val expectedBazelPathSpec = BazelPathSpec(Path("/usr/local/bin/bazel"))
             bazelPathSpec shouldBe expectedBazelPathSpec
         }
 

--- a/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpecMapperTest.kt
+++ b/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpecMapperTest.kt
@@ -20,7 +20,7 @@ class TargetsSpecMapperTest {
 
         @Nested
         @DisplayName("without derive_targets_from_targets")
-        inner class MapTestWithoutDeriveTargetsFlag {
+        inner class MapTestWithoutderiveTargetsFromDirectoriesSection {
             @Test
             fun `should return success with default spec if targets are null`() {
                 // given
@@ -123,13 +123,13 @@ class TargetsSpecMapperTest {
 
         @Nested
         @DisplayName("with derive_targets_from_targets false")
-        inner class MapTestWithDeriveTargetsFlagFalse {
+        inner class MapTestWithderiveTargetsFromDirectoriesSectionFalse {
             @Test
             fun `should return success with default spec if targets are null and flag is false`() {
                 // given
                 val projectView = ProjectView.Builder(
                         targets = null,
-                        deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)).build().get()
+                        deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)).build().get()
 
                 // when
                 val targetsSpecTry = TargetsSpecMapper.map(projectView)
@@ -150,7 +150,7 @@ class TargetsSpecMapperTest {
                                 emptyList(),
                                 emptyList()
                         ),
-                        deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                        deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build().get()
 
                 // when
@@ -175,7 +175,7 @@ class TargetsSpecMapperTest {
                                         BuildTargetIdentifier("//excluded_target2"),
                                 )
                         ),
-                        deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                        deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build().get()
 
                 // when
@@ -203,7 +203,7 @@ class TargetsSpecMapperTest {
                                                 BuildTargetIdentifier("//excluded_target2"),
                                         ),
                                 ),
-                                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                         ).build().get()
 
                 // when
@@ -231,14 +231,14 @@ class TargetsSpecMapperTest {
 
         @Nested
         @DisplayName("with derive_targets_from_targets true")
-        inner class MapTestWithDeriveTargetsFlagTrue {
+        inner class MapTestWithderiveTargetsFromDirectoriesSectionTrue {
             @Test
             fun `should return success with default spec if targets and directories are null and flag is true`() {
                 // given
                 val projectView = ProjectView.Builder(
                         targets = null,
                         directories = null,
-                        deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)).build().get()
+                        deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)).build().get()
 
                 // when
                 val targetsSpecTry = TargetsSpecMapper.map(projectView)
@@ -263,7 +263,7 @@ class TargetsSpecMapperTest {
                                 emptyList(),
                                 emptyList()
                         ),
-                        deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                        deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build().get()
 
                 // when
@@ -294,7 +294,7 @@ class TargetsSpecMapperTest {
                                         Path("excluded_target1"),
                                         Path("excluded_target2"),)
                         ),
-                        deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                        deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build().get()
 
                 // when
@@ -326,7 +326,7 @@ class TargetsSpecMapperTest {
                                                 Path("excluded_dir2"),
                                         ),
                                 ),
-                                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                         ).build().get()
 
                 // when
@@ -378,7 +378,7 @@ class TargetsSpecMapperTest {
                                                 Path("excluded_dir2"),
                                         ),
                                 ),
-                                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                         ).build().get()
 
                 // when
@@ -428,7 +428,7 @@ class TargetsSpecMapperTest {
                                                 Path("excluded_dir2/"),
                                         ),
                                 ),
-                                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                         ).build().get()
 
                 // when

--- a/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpecMapperTest.kt
+++ b/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpecMapperTest.kt
@@ -129,7 +129,7 @@ class TargetsSpecMapperTest {
                 // given
                 val projectView = ProjectView.Builder(
                         targets = null,
-                        deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)).build().get()
+                        deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(false)).build().get()
 
                 // when
                 val targetsSpecTry = TargetsSpecMapper.map(projectView)
@@ -150,7 +150,7 @@ class TargetsSpecMapperTest {
                                 emptyList(),
                                 emptyList()
                         ),
-                        deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                        deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build().get()
 
                 // when
@@ -175,7 +175,7 @@ class TargetsSpecMapperTest {
                                         BuildTargetIdentifier("//excluded_target2"),
                                 )
                         ),
-                        deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                        deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build().get()
 
                 // when
@@ -203,7 +203,7 @@ class TargetsSpecMapperTest {
                                                 BuildTargetIdentifier("//excluded_target2"),
                                         ),
                                 ),
-                                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(false)
+                                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                         ).build().get()
 
                 // when
@@ -238,7 +238,7 @@ class TargetsSpecMapperTest {
                 val projectView = ProjectView.Builder(
                         targets = null,
                         directories = null,
-                        deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)).build().get()
+                        deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)).build().get()
 
                 // when
                 val targetsSpecTry = TargetsSpecMapper.map(projectView)
@@ -263,7 +263,7 @@ class TargetsSpecMapperTest {
                                 emptyList(),
                                 emptyList()
                         ),
-                        deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                        deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build().get()
 
                 // when
@@ -294,7 +294,7 @@ class TargetsSpecMapperTest {
                                         Path("excluded_target1"),
                                         Path("excluded_target2"),)
                         ),
-                        deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                        deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build().get()
 
                 // when
@@ -326,7 +326,7 @@ class TargetsSpecMapperTest {
                                                 Path("excluded_dir2"),
                                         ),
                                 ),
-                                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                         ).build().get()
 
                 // when
@@ -378,7 +378,7 @@ class TargetsSpecMapperTest {
                                                 Path("excluded_dir2"),
                                         ),
                                 ),
-                                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                         ).build().get()
 
                 // when
@@ -428,7 +428,7 @@ class TargetsSpecMapperTest {
                                                 Path("excluded_dir2/"),
                                         ),
                                 ),
-                                deriveTargetsFromDirectoriesSection = ProjectViewDeriveTargetsFromDirectoriesSection(true)
+                                deriveTargetsFromDirectories = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                         ).build().get()
 
                 // when

--- a/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpecMapperTest.kt
+++ b/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpecMapperTest.kt
@@ -318,12 +318,12 @@ class TargetsSpecMapperTest {
                                 directories = ProjectViewDirectoriesSection(
                                         listOf(
                                                 Path("included_dir1"),
-                                                Path("included_dir1/"),
-                                                Path("included_dir1")
+                                                Path("included_dir2/"),
+                                                Path("included_dir3")
                                         ),
                                         listOf(
                                                 Path("excluded_dir1"),
-                                                Path("excluded_dir1"),
+                                                Path("excluded_dir2"),
                                         ),
                                 ),
                                 deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
@@ -340,12 +340,12 @@ class TargetsSpecMapperTest {
                         TargetsSpec(
                                 listOf(
                                         BuildTargetIdentifier("//included_dir1/..."),
-                                        BuildTargetIdentifier("//included_dir1/..."),
-                                        BuildTargetIdentifier("//included_dir1/..."),
+                                        BuildTargetIdentifier("//included_dir2/..."),
+                                        BuildTargetIdentifier("//included_dir3/..."),
                                 ),
                                 listOf(
                                         BuildTargetIdentifier("//excluded_dir1/..."),
-                                        BuildTargetIdentifier("//excluded_dir1/..."),
+                                        BuildTargetIdentifier("//excluded_dir2/..."),
                                 ),
                         )
                 targetsSpec shouldBe expectedTargets
@@ -370,12 +370,12 @@ class TargetsSpecMapperTest {
                                 directories = ProjectViewDirectoriesSection(
                                         listOf(
                                                 Path("included_dir1"),
-                                                Path("included_dir1/"),
-                                                Path("included_dir1")
+                                                Path("included_dir2/"),
+                                                Path("included_dir3")
                                         ),
                                         listOf(
                                                 Path("excluded_dir1"),
-                                                Path("excluded_dir1"),
+                                                Path("excluded_dir2"),
                                         ),
                                 ),
                                 deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
@@ -395,14 +395,59 @@ class TargetsSpecMapperTest {
                                         BuildTargetIdentifier("//included_target2"),
                                         BuildTargetIdentifier("//included_target3"),
                                         BuildTargetIdentifier("//included_dir1/..."),
-                                        BuildTargetIdentifier("//included_dir1/..."),
-                                        BuildTargetIdentifier("//included_dir1/..."),
+                                        BuildTargetIdentifier("//included_dir2/..."),
+                                        BuildTargetIdentifier("//included_dir3/..."),
                                 ),
                                 listOf(
                                         BuildTargetIdentifier("//excluded_target1"),
                                         BuildTargetIdentifier("//excluded_target2"),
                                         BuildTargetIdentifier("//excluded_dir1/..."),
+                                        BuildTargetIdentifier("//excluded_dir2/..."),
+                                ),
+                        )
+                targetsSpec shouldBe expectedTargets
+            }
+
+            @Test
+            fun `should return success for successful mapping with different directory cases`() {
+                // given
+                val projectView =
+                        ProjectView.Builder(
+                                targets = ProjectViewTargetsSection(
+                                        emptyList(),
+                                        emptyList()
+                                ),
+                                directories = ProjectViewDirectoriesSection(
+                                        listOf(
+                                                Path("included_dir1/"),
+                                                Path("included_dir2/"),
+                                                Path(".")
+                                        ),
+                                        listOf(
+                                                Path("excluded_dir1/"),
+                                                Path("excluded_dir2/"),
+                                        ),
+                                ),
+                                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                        ).build().get()
+
+                // when
+                val targetsSpecTry = TargetsSpecMapper.map(projectView)
+
+                // then
+                targetsSpecTry.isSuccess shouldBe true
+                val targetsSpec = targetsSpecTry.get()
+
+                val expectedTargets =
+                        TargetsSpec(
+                                listOf(
+                                        BuildTargetIdentifier("//included_dir1/..."),
+                                        BuildTargetIdentifier("//included_dir2/..."),
+                                        BuildTargetIdentifier("//./..."),
+                                ),
+                                listOf(
                                         BuildTargetIdentifier("//excluded_dir1/..."),
+                                        BuildTargetIdentifier("//excluded_dir2/..."),
                                 ),
                         )
                 targetsSpec shouldBe expectedTargets

--- a/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpecMapperTest.kt
+++ b/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpecMapperTest.kt
@@ -4,7 +4,7 @@ import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import io.kotest.matchers.shouldBe
 import org.jetbrains.bsp.bazel.executioncontext.api.ProjectViewToExecutionContextEntityMapperException
 import org.jetbrains.bsp.bazel.projectview.model.ProjectView
-import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDeriveTargetsFlagSection
+import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDeriveTargetsFromDirectoriesSection
 import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDirectoriesSection
 import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewTargetsSection
 import org.junit.jupiter.api.DisplayName
@@ -129,7 +129,7 @@ class TargetsSpecMapperTest {
                 // given
                 val projectView = ProjectView.Builder(
                         targets = null,
-                        deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(false)).build().get()
+                        deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)).build().get()
 
                 // when
                 val targetsSpecTry = TargetsSpecMapper.map(projectView)
@@ -150,7 +150,7 @@ class TargetsSpecMapperTest {
                                 emptyList(),
                                 emptyList()
                         ),
-                        deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(false)
+                        deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build().get()
 
                 // when
@@ -175,7 +175,7 @@ class TargetsSpecMapperTest {
                                         BuildTargetIdentifier("//excluded_target2"),
                                 )
                         ),
-                        deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(false)
+                        deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                 ).build().get()
 
                 // when
@@ -203,7 +203,7 @@ class TargetsSpecMapperTest {
                                                 BuildTargetIdentifier("//excluded_target2"),
                                         ),
                                 ),
-                                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(false)
+                                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(false)
                         ).build().get()
 
                 // when
@@ -238,7 +238,7 @@ class TargetsSpecMapperTest {
                 val projectView = ProjectView.Builder(
                         targets = null,
                         directories = null,
-                        deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)).build().get()
+                        deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)).build().get()
 
                 // when
                 val targetsSpecTry = TargetsSpecMapper.map(projectView)
@@ -263,7 +263,7 @@ class TargetsSpecMapperTest {
                                 emptyList(),
                                 emptyList()
                         ),
-                        deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                        deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build().get()
 
                 // when
@@ -294,7 +294,7 @@ class TargetsSpecMapperTest {
                                         Path("excluded_target1"),
                                         Path("excluded_target2"),)
                         ),
-                        deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                        deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                 ).build().get()
 
                 // when
@@ -326,7 +326,7 @@ class TargetsSpecMapperTest {
                                                 Path("excluded_dir2"),
                                         ),
                                 ),
-                                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                         ).build().get()
 
                 // when
@@ -378,7 +378,7 @@ class TargetsSpecMapperTest {
                                                 Path("excluded_dir2"),
                                         ),
                                 ),
-                                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                         ).build().get()
 
                 // when
@@ -428,7 +428,7 @@ class TargetsSpecMapperTest {
                                                 Path("excluded_dir2/"),
                                         ),
                                 ),
-                                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                                deriveTargetsFlag = ProjectViewDeriveTargetsFromDirectoriesSection(true)
                         ).build().get()
 
                 // when
@@ -443,7 +443,7 @@ class TargetsSpecMapperTest {
                                 listOf(
                                         BuildTargetIdentifier("//included_dir1/..."),
                                         BuildTargetIdentifier("//included_dir2/..."),
-                                        BuildTargetIdentifier("//./..."),
+                                        BuildTargetIdentifier("//..."),
                                 ),
                                 listOf(
                                         BuildTargetIdentifier("//excluded_dir1/..."),

--- a/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpecMapperTest.kt
+++ b/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/TargetsSpecMapperTest.kt
@@ -4,10 +4,13 @@ import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import io.kotest.matchers.shouldBe
 import org.jetbrains.bsp.bazel.executioncontext.api.ProjectViewToExecutionContextEntityMapperException
 import org.jetbrains.bsp.bazel.projectview.model.ProjectView
+import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDeriveTargetsFlagSection
+import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewDirectoriesSection
 import org.jetbrains.bsp.bazel.projectview.model.sections.ProjectViewTargetsSection
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import kotlin.io.path.Path
 
 class TargetsSpecMapperTest {
 
@@ -15,103 +18,395 @@ class TargetsSpecMapperTest {
     @DisplayName("fun map(projectView): Try<TargetsSpec> tests")
     inner class MapTest {
 
-        @Test
-        fun `should return success with default spec if targets are null`() {
-            // given
-            val projectView = ProjectView.Builder(targets = null).build().get()
+        @Nested
+        @DisplayName("without derive_targets_from_targets")
+        inner class MapTestWithoutDeriveTargetsFlag {
+            @Test
+            fun `should return success with default spec if targets are null`() {
+                // given
+                val projectView = ProjectView.Builder(targets = null).build().get()
 
-            // when
-            val targetsSpecTry = TargetsSpecMapper.map(projectView)
+                // when
+                val targetsSpecTry = TargetsSpecMapper.map(projectView)
 
-            // then
-            targetsSpecTry.isSuccess shouldBe true
-            val targetsSpec = targetsSpecTry.get()
+                // then
+                targetsSpecTry.isSuccess shouldBe true
+                val targetsSpec = targetsSpecTry.get()
 
-            val expectedTargetsSpec = TargetsSpec(listOf(BuildTargetIdentifier("//...")), emptyList())
-            targetsSpec shouldBe expectedTargetsSpec
-        }
+                val expectedTargetsSpec = TargetsSpec(listOf(BuildTargetIdentifier("//...")), emptyList())
+                targetsSpec shouldBe expectedTargetsSpec
+            }
 
-        @Test
-        fun `should return success and default if targets have no values`() {
-            // given
-            val projectView = ProjectView.Builder(
-                targets = ProjectViewTargetsSection(
-                    emptyList(),
-                    emptyList()
-                )
-            ).build().get()
-
-            // when
-            val targetsSpecTry = TargetsSpecMapper.map(projectView)
-
-            // then
-            targetsSpecTry.isSuccess shouldBe true
-            val targetsSpec = targetsSpecTry.get()
-
-            val expectedTargetsSpec = TargetsSpec(listOf(BuildTargetIdentifier("//...")), emptyList())
-            targetsSpec shouldBe expectedTargetsSpec
-        }
-
-        @Test
-        fun `should return fail if targets have no included values`() {
-            // given
-            val projectView = ProjectView.Builder(
-                targets = ProjectViewTargetsSection(
-                    emptyList(),
-                    listOf(
-                        BuildTargetIdentifier("//excluded_target1"),
-                        BuildTargetIdentifier("//excluded_target2"),
-                    )
-                )
-            ).build().get()
-
-            // when
-            val targetsSpecTry = TargetsSpecMapper.map(projectView)
-
-            // then
-            targetsSpecTry.isFailure shouldBe true
-            targetsSpecTry.cause::class shouldBe ProjectViewToExecutionContextEntityMapperException::class
-            targetsSpecTry.cause.message shouldBe "Mapping project view into 'targets' failed! 'targets' section has no included targets."
-        }
-
-        @Test
-        fun `should return success for successful mapping`() {
-            // given
-            val projectView =
-                ProjectView.Builder(
-                    targets = ProjectViewTargetsSection(
-                        listOf(
-                            BuildTargetIdentifier("//included_target1"),
-                            BuildTargetIdentifier("//included_target2"),
-                            BuildTargetIdentifier("//included_target3")
-                        ),
-                        listOf(
-                            BuildTargetIdentifier("//excluded_target1"),
-                            BuildTargetIdentifier("//excluded_target2"),
-                        ),
-                    )
+            @Test
+            fun `should return success and default if targets have no values`() {
+                // given
+                val projectView = ProjectView.Builder(
+                        targets = ProjectViewTargetsSection(
+                                emptyList(),
+                                emptyList()
+                        )
                 ).build().get()
 
-            // when
-            val targetsSpecTry = TargetsSpecMapper.map(projectView)
+                // when
+                val targetsSpecTry = TargetsSpecMapper.map(projectView)
 
-            // then
-            targetsSpecTry.isSuccess shouldBe true
-            val targetsSpec = targetsSpecTry.get()
+                // then
+                targetsSpecTry.isSuccess shouldBe true
+                val targetsSpec = targetsSpecTry.get()
 
-            val expectedTargets =
-                TargetsSpec(
-                    listOf(
-                        BuildTargetIdentifier("//included_target1"),
-                        BuildTargetIdentifier("//included_target2"),
-                        BuildTargetIdentifier("//included_target3"),
-                    ),
-                    listOf(
-                        BuildTargetIdentifier("//excluded_target1"),
-                        BuildTargetIdentifier("//excluded_target2"),
-                    ),
-                )
-            targetsSpec shouldBe expectedTargets
+                val expectedTargetsSpec = TargetsSpec(listOf(BuildTargetIdentifier("//...")), emptyList())
+                targetsSpec shouldBe expectedTargetsSpec
+            }
+
+            @Test
+            fun `should return fail if targets have no included values`() {
+                // given
+                val projectView = ProjectView.Builder(
+                        targets = ProjectViewTargetsSection(
+                                emptyList(),
+                                listOf(
+                                        BuildTargetIdentifier("//excluded_target1"),
+                                        BuildTargetIdentifier("//excluded_target2"),
+                                )
+                        )
+                ).build().get()
+
+                // when
+                val targetsSpecTry = TargetsSpecMapper.map(projectView)
+
+                // then
+                targetsSpecTry.isFailure shouldBe true
+                targetsSpecTry.cause::class shouldBe ProjectViewToExecutionContextEntityMapperException::class
+                targetsSpecTry.cause.message shouldBe "Mapping project view into 'targets' failed! 'targets' section has no included targets."
+            }
+
+            @Test
+            fun `should return success for successful mapping`() {
+                // given
+                val projectView =
+                        ProjectView.Builder(
+                                targets = ProjectViewTargetsSection(
+                                        listOf(
+                                                BuildTargetIdentifier("//included_target1"),
+                                                BuildTargetIdentifier("//included_target2"),
+                                                BuildTargetIdentifier("//included_target3")
+                                        ),
+                                        listOf(
+                                                BuildTargetIdentifier("//excluded_target1"),
+                                                BuildTargetIdentifier("//excluded_target2"),
+                                        ),
+                                )
+                        ).build().get()
+
+                // when
+                val targetsSpecTry = TargetsSpecMapper.map(projectView)
+
+                // then
+                targetsSpecTry.isSuccess shouldBe true
+                val targetsSpec = targetsSpecTry.get()
+
+                val expectedTargets =
+                        TargetsSpec(
+                                listOf(
+                                        BuildTargetIdentifier("//included_target1"),
+                                        BuildTargetIdentifier("//included_target2"),
+                                        BuildTargetIdentifier("//included_target3"),
+                                ),
+                                listOf(
+                                        BuildTargetIdentifier("//excluded_target1"),
+                                        BuildTargetIdentifier("//excluded_target2"),
+                                ),
+                        )
+                targetsSpec shouldBe expectedTargets
+            }
+        }
+
+        @Nested
+        @DisplayName("with derive_targets_from_targets false")
+        inner class MapTestWithDeriveTargetsFlagFalse {
+            @Test
+            fun `should return success with default spec if targets are null and flag is false`() {
+                // given
+                val projectView = ProjectView.Builder(
+                        targets = null,
+                        deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(false)).build().get()
+
+                // when
+                val targetsSpecTry = TargetsSpecMapper.map(projectView)
+
+                // then
+                targetsSpecTry.isSuccess shouldBe true
+                val targetsSpec = targetsSpecTry.get()
+
+                val expectedTargetsSpec = TargetsSpec(listOf(BuildTargetIdentifier("//...")), emptyList())
+                targetsSpec shouldBe expectedTargetsSpec
+            }
+
+            @Test
+            fun `should return success and default if targets have no values and flag is false`() {
+                // given
+                val projectView = ProjectView.Builder(
+                        targets = ProjectViewTargetsSection(
+                                emptyList(),
+                                emptyList()
+                        ),
+                        deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(false)
+                ).build().get()
+
+                // when
+                val targetsSpecTry = TargetsSpecMapper.map(projectView)
+
+                // then
+                targetsSpecTry.isSuccess shouldBe true
+                val targetsSpec = targetsSpecTry.get()
+
+                val expectedTargetsSpec = TargetsSpec(listOf(BuildTargetIdentifier("//...")), emptyList())
+                targetsSpec shouldBe expectedTargetsSpec
+            }
+
+            @Test
+            fun `should return fail if targets have no included values and flag is False`() {
+                // given
+                val projectView = ProjectView.Builder(
+                        targets = ProjectViewTargetsSection(
+                                emptyList(),
+                                listOf(
+                                        BuildTargetIdentifier("//excluded_target1"),
+                                        BuildTargetIdentifier("//excluded_target2"),
+                                )
+                        ),
+                        deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(false)
+                ).build().get()
+
+                // when
+                val targetsSpecTry = TargetsSpecMapper.map(projectView)
+
+                // then
+                targetsSpecTry.isFailure shouldBe true
+                targetsSpecTry.cause::class shouldBe ProjectViewToExecutionContextEntityMapperException::class
+                targetsSpecTry.cause.message shouldBe "Mapping project view into 'targets' failed! 'targets' section has no included targets."
+            }
+
+            @Test
+            fun `should return success for successful mapping`() {
+                // given
+                val projectView =
+                        ProjectView.Builder(
+                                targets = ProjectViewTargetsSection(
+                                        listOf(
+                                                BuildTargetIdentifier("//included_target1"),
+                                                BuildTargetIdentifier("//included_target2"),
+                                                BuildTargetIdentifier("//included_target3")
+                                        ),
+                                        listOf(
+                                                BuildTargetIdentifier("//excluded_target1"),
+                                                BuildTargetIdentifier("//excluded_target2"),
+                                        ),
+                                ),
+                                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(false)
+                        ).build().get()
+
+                // when
+                val targetsSpecTry = TargetsSpecMapper.map(projectView)
+
+                // then
+                targetsSpecTry.isSuccess shouldBe true
+                val targetsSpec = targetsSpecTry.get()
+
+                val expectedTargets =
+                        TargetsSpec(
+                                listOf(
+                                        BuildTargetIdentifier("//included_target1"),
+                                        BuildTargetIdentifier("//included_target2"),
+                                        BuildTargetIdentifier("//included_target3"),
+                                ),
+                                listOf(
+                                        BuildTargetIdentifier("//excluded_target1"),
+                                        BuildTargetIdentifier("//excluded_target2"),
+                                ),
+                        )
+                targetsSpec shouldBe expectedTargets
+            }
+        }
+
+        @Nested
+        @DisplayName("with derive_targets_from_targets true")
+        inner class MapTestWithDeriveTargetsFlagTrue {
+            @Test
+            fun `should return success with default spec if targets and directories are null and flag is true`() {
+                // given
+                val projectView = ProjectView.Builder(
+                        targets = null,
+                        directories = null,
+                        deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)).build().get()
+
+                // when
+                val targetsSpecTry = TargetsSpecMapper.map(projectView)
+
+                // then
+                targetsSpecTry.isSuccess shouldBe true
+                val targetsSpec = targetsSpecTry.get()
+
+                val expectedTargetsSpec = TargetsSpec(listOf(BuildTargetIdentifier("//...")), emptyList())
+                targetsSpec shouldBe expectedTargetsSpec
+            }
+
+            @Test
+            fun `should return success and default if targets and directories have no values and flag is true`() {
+                // given
+                val projectView = ProjectView.Builder(
+                        targets = ProjectViewTargetsSection(
+                                emptyList(),
+                                emptyList()
+                        ),
+                        directories = ProjectViewDirectoriesSection(
+                                emptyList(),
+                                emptyList()
+                        ),
+                        deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                ).build().get()
+
+                // when
+                val targetsSpecTry = TargetsSpecMapper.map(projectView)
+
+                // then
+                targetsSpecTry.isSuccess shouldBe true
+                val targetsSpec = targetsSpecTry.get()
+
+                val expectedTargetsSpec = TargetsSpec(listOf(BuildTargetIdentifier("//...")), emptyList())
+                targetsSpec shouldBe expectedTargetsSpec
+            }
+
+            @Test
+            fun `should return fail if directories have no included values and flag is True`() {
+                // given
+                val projectView = ProjectView.Builder(
+                        targets = ProjectViewTargetsSection(
+                                emptyList(),
+                                listOf(
+                                        BuildTargetIdentifier("//excluded_target1"),
+                                        BuildTargetIdentifier("//excluded_target2"),
+                                )
+                        ),
+                        directories = ProjectViewDirectoriesSection(
+                                emptyList(),
+                                listOf(
+                                        Path("excluded_target1"),
+                                        Path("excluded_target2"),)
+                        ),
+                        deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                ).build().get()
+
+                // when
+                val targetsSpecTry = TargetsSpecMapper.map(projectView)
+
+                // then
+                targetsSpecTry.isFailure shouldBe true
+                targetsSpecTry.cause::class shouldBe ProjectViewToExecutionContextEntityMapperException::class
+                targetsSpecTry.cause.message shouldBe "Mapping project view into 'targets' failed! 'directories' section has no included targets."
+            }
+
+            @Test
+            fun `should return success for successful mapping with empty targets`() {
+                // given
+                val projectView =
+                        ProjectView.Builder(
+                                targets = ProjectViewTargetsSection(
+                                        emptyList(),
+                                        emptyList()
+                                ),
+                                directories = ProjectViewDirectoriesSection(
+                                        listOf(
+                                                Path("included_dir1"),
+                                                Path("included_dir1/"),
+                                                Path("included_dir1")
+                                        ),
+                                        listOf(
+                                                Path("excluded_dir1"),
+                                                Path("excluded_dir1"),
+                                        ),
+                                ),
+                                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                        ).build().get()
+
+                // when
+                val targetsSpecTry = TargetsSpecMapper.map(projectView)
+
+                // then
+                targetsSpecTry.isSuccess shouldBe true
+                val targetsSpec = targetsSpecTry.get()
+
+                val expectedTargets =
+                        TargetsSpec(
+                                listOf(
+                                        BuildTargetIdentifier("//included_dir1/..."),
+                                        BuildTargetIdentifier("//included_dir1/..."),
+                                        BuildTargetIdentifier("//included_dir1/..."),
+                                ),
+                                listOf(
+                                        BuildTargetIdentifier("//excluded_dir1/..."),
+                                        BuildTargetIdentifier("//excluded_dir1/..."),
+                                ),
+                        )
+                targetsSpec shouldBe expectedTargets
+            }
+
+            @Test
+            fun `should return success for successful mapping with non-empty targets`() {
+                // given
+                val projectView =
+                        ProjectView.Builder(
+                                targets = ProjectViewTargetsSection(
+                                        listOf(
+                                                BuildTargetIdentifier("//included_target1"),
+                                                BuildTargetIdentifier("//included_target2"),
+                                                BuildTargetIdentifier("//included_target3")
+                                        ),
+                                        listOf(
+                                                BuildTargetIdentifier("//excluded_target1"),
+                                                BuildTargetIdentifier("//excluded_target2"),
+                                        )
+                                ),
+                                directories = ProjectViewDirectoriesSection(
+                                        listOf(
+                                                Path("included_dir1"),
+                                                Path("included_dir1/"),
+                                                Path("included_dir1")
+                                        ),
+                                        listOf(
+                                                Path("excluded_dir1"),
+                                                Path("excluded_dir1"),
+                                        ),
+                                ),
+                                deriveTargetsFlag = ProjectViewDeriveTargetsFlagSection(true)
+                        ).build().get()
+
+                // when
+                val targetsSpecTry = TargetsSpecMapper.map(projectView)
+
+                // then
+                targetsSpecTry.isSuccess shouldBe true
+                val targetsSpec = targetsSpecTry.get()
+
+                val expectedTargets =
+                        TargetsSpec(
+                                listOf(
+                                        BuildTargetIdentifier("//included_target1"),
+                                        BuildTargetIdentifier("//included_target2"),
+                                        BuildTargetIdentifier("//included_target3"),
+                                        BuildTargetIdentifier("//included_dir1/..."),
+                                        BuildTargetIdentifier("//included_dir1/..."),
+                                        BuildTargetIdentifier("//included_dir1/..."),
+                                ),
+                                listOf(
+                                        BuildTargetIdentifier("//excluded_target1"),
+                                        BuildTargetIdentifier("//excluded_target2"),
+                                        BuildTargetIdentifier("//excluded_dir1/..."),
+                                        BuildTargetIdentifier("//excluded_dir1/..."),
+                                ),
+                        )
+                targetsSpec shouldBe expectedTargets
+            }
         }
     }
 

--- a/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/WorkspaceContextConstructorTest.kt
+++ b/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/WorkspaceContextConstructorTest.kt
@@ -112,7 +112,7 @@ class WorkspaceContextConstructorTest {
             val expectedWorkspaceContext = WorkspaceContext(
                 targets = TargetsSpec(listOf(BuildTargetIdentifier("//...")), emptyList()),
                 buildFlags = BuildFlagsSpec(emptyList()),
-                bazelPath = BazelPathSpec(Path("/opt/twitter_mde/bin/bazel")),
+                bazelPath = BazelPathSpec(Path("/usr/local/bin/bazel")),
                 dotBazelBspDirPath = DotBazelBspDirPathSpec(Path("").toAbsolutePath().resolve(".bazelbsp"))
             )
             workspaceContext shouldBe expectedWorkspaceContext

--- a/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/WorkspaceContextConstructorTest.kt
+++ b/executioncontext/workspacecontext/src/test/java/org/jetbrains/bsp/bazel/workspacecontext/WorkspaceContextConstructorTest.kt
@@ -112,7 +112,7 @@ class WorkspaceContextConstructorTest {
             val expectedWorkspaceContext = WorkspaceContext(
                 targets = TargetsSpec(listOf(BuildTargetIdentifier("//...")), emptyList()),
                 buildFlags = BuildFlagsSpec(emptyList()),
-                bazelPath = BazelPathSpec(Path("/usr/local/bin/bazel")),
+                bazelPath = BazelPathSpec(Path("/opt/twitter_mde/bin/bazel")),
                 dotBazelBspDirPath = DotBazelBspDirPathSpec(Path("").toAbsolutePath().resolve(".bazelbsp"))
             )
             workspaceContext shouldBe expectedWorkspaceContext

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/ProjectViewCLiOptionsProvider.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/ProjectViewCLiOptionsProvider.kt
@@ -71,6 +71,6 @@ object ProjectViewCLiOptionsProvider {
     private fun toBuildFlagsSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewBuildFlagsSection? =
             projectViewCliOptions?.buildFlags?.let { ProjectViewBuildFlagsSection(it) }
 
-    private fun toDeriveTargetFlagSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewDeriveTargetsFlagSection? =
-            projectViewCliOptions?.deriveTargetsFlag?.let(::ProjectViewDeriveTargetsFlagSection)
+    private fun toDeriveTargetFlagSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewDeriveTargetsFromDirectoriesSection? =
+            projectViewCliOptions?.deriveTargetsFromDirectories?.let(::ProjectViewDeriveTargetsFromDirectoriesSection)
 }

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/ProjectViewCLiOptionsProvider.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/ProjectViewCLiOptionsProvider.kt
@@ -29,7 +29,7 @@ object ProjectViewCLiOptionsProvider {
                     targets = toTargetsSection(projectViewCliOptions),
                     buildFlags = toBuildFlagsSection(projectViewCliOptions),
                     directories = toDirectoriesSection(projectViewCliOptions),
-                    deriveTargetsFromDirectoriesSection = toDeriveTargetFlagSection(projectViewCliOptions)
+                    deriveTargetsFromDirectories = toDeriveTargetFlagSection(projectViewCliOptions)
             )
 
     private fun toJavaPathSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewJavaPathSection? =

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/ProjectViewCLiOptionsProvider.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/ProjectViewCLiOptionsProvider.kt
@@ -42,8 +42,8 @@ object ProjectViewCLiOptionsProvider {
             projectViewCliOptions?.targets?.let(::toTargetsSectionNotNull)
 
     private fun toTargetsSectionNotNull(targets: List<String>): ProjectViewTargetsSection {
-        val includedTargets = calculateIncludedValues(targets)
-        val excludedTargets = calculateExcludedValues(targets)
+        val includedTargets = calculateIncludedValues(targets).map(::BuildTargetIdentifier)
+        val excludedTargets = calculateExcludedValues(targets).map(::BuildTargetIdentifier)
 
         return ProjectViewTargetsSection(includedTargets, excludedTargets)
     }
@@ -52,29 +52,18 @@ object ProjectViewCLiOptionsProvider {
             projectViewCliOptions?.directories?.let(::toDirectoriesSectionNotNull)
 
     private fun toDirectoriesSectionNotNull(directories: List<String>): ProjectViewDirectoriesSection {
-        val includedDirectories = calculateIncludedDirs(directories)
-        val excludedDirectories = calculateExcludedDirs(directories)
+        val includedDirectories = calculateIncludedValues(directories).map(::Path)
+        val excludedDirectories = calculateExcludedValues(directories).map(::Path)
 
         return ProjectViewDirectoriesSection(includedDirectories, excludedDirectories)
     }
 
-    private fun calculateIncludedValues(targets: List<String>): List<BuildTargetIdentifier> =
+    private fun calculateIncludedValues(targets: List<String>): List<String> =
             targets.filterNot { it.startsWith(EXCLUDED_TARGET_PREFIX) }
-                    .map(::BuildTargetIdentifier)
 
-    private fun calculateExcludedValues(targets: List<String>): List<BuildTargetIdentifier> =
+    private fun calculateExcludedValues(targets: List<String>): List<String> =
             targets.filter { it.startsWith(EXCLUDED_TARGET_PREFIX) }
                     .map { it.drop(1) }
-                    .map(::BuildTargetIdentifier)
-
-    private fun calculateIncludedDirs(targets: List<String>): List<Path> =
-            targets.filterNot { it.startsWith(EXCLUDED_TARGET_PREFIX) }
-                    .map(::Path)
-
-    private fun calculateExcludedDirs(targets: List<String>): List<Path> =
-            targets.filter { it.startsWith(EXCLUDED_TARGET_PREFIX) }
-                    .map { it.drop(1) }
-                    .map(::Path)
 
     private fun toDebuggerAddressSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewDebuggerAddressSection? =
             projectViewCliOptions?.debuggerAddress?.let(::ProjectViewDebuggerAddressSection)

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/ProjectViewCLiOptionsProvider.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/ProjectViewCLiOptionsProvider.kt
@@ -29,7 +29,7 @@ object ProjectViewCLiOptionsProvider {
                     targets = toTargetsSection(projectViewCliOptions),
                     buildFlags = toBuildFlagsSection(projectViewCliOptions),
                     directories = toDirectoriesSection(projectViewCliOptions),
-                    deriveTargetsFlag = toDeriveTargetFlagSection(projectViewCliOptions)
+                    deriveTargetsFromDirectoriesSection = toDeriveTargetFlagSection(projectViewCliOptions)
             )
 
     private fun toJavaPathSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewJavaPathSection? =

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/ProjectViewCLiOptionsProvider.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/ProjectViewCLiOptionsProvider.kt
@@ -27,6 +27,8 @@ object ProjectViewCLiOptionsProvider {
                     debuggerAddress = toDebuggerAddressSection(projectViewCliOptions),
                     targets = toTargetsSection(projectViewCliOptions),
                     buildFlags = toBuildFlagsSection(projectViewCliOptions),
+                    directories = toDirectoriesSection(projectViewCliOptions),
+                    deriveTargetsFlag = toDeriveTargetFlagSection(projectViewCliOptions)
             )
 
     private fun toJavaPathSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewJavaPathSection? =
@@ -45,6 +47,16 @@ object ProjectViewCLiOptionsProvider {
         return ProjectViewTargetsSection(includedTargets, excludedTargets)
     }
 
+    private fun toDirectoriesSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewDirectoriesSection? =
+            projectViewCliOptions?.directories?.let(::toDirectoriesSectionNotNull)
+
+    private fun toDirectoriesSectionNotNull(directories: List<String>?): ProjectViewDirectoriesSection {
+        val includedDirectories = calculateIncludedTargets(directories)
+        val excludedDirectories = calculateExcludedTargets(directories)
+
+        return ProjectViewDirectoriesSection(includedDirectories, excludedDirectories)
+    }
+
     private fun calculateIncludedTargets(targets: List<String>?): List<BuildTargetIdentifier> =
             targets.orEmpty()
                     .filterNot { it.startsWith(EXCLUDED_TARGET_PREFIX) }
@@ -61,4 +73,7 @@ object ProjectViewCLiOptionsProvider {
 
     private fun toBuildFlagsSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewBuildFlagsSection? =
             projectViewCliOptions?.buildFlags?.let { ProjectViewBuildFlagsSection(it) }
+
+    private fun toDeriveTargetFlagSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewDeriveTargetsFlagSection? =
+            projectViewCliOptions?.deriveTargetsFlag?.let(::ProjectViewDeriveTargetsFlagSection)
 }

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/ProjectViewCLiOptionsProvider.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/ProjectViewCLiOptionsProvider.kt
@@ -8,6 +8,7 @@ import org.jetbrains.bsp.bazel.projectview.generator.DefaultProjectViewGenerator
 import org.jetbrains.bsp.bazel.projectview.model.ProjectView
 import org.jetbrains.bsp.bazel.projectview.model.sections.*
 import java.nio.file.Path
+import kotlin.io.path.Path
 
 object ProjectViewCLiOptionsProvider {
 
@@ -40,9 +41,9 @@ object ProjectViewCLiOptionsProvider {
     private fun toTargetsSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewTargetsSection? =
             projectViewCliOptions?.targets?.let(::toTargetsSectionNotNull)
 
-    private fun toTargetsSectionNotNull(targets: List<String>?): ProjectViewTargetsSection {
-        val includedTargets = calculateIncludedTargets(targets)
-        val excludedTargets = calculateExcludedTargets(targets)
+    private fun toTargetsSectionNotNull(targets: List<String>): ProjectViewTargetsSection {
+        val includedTargets = calculateIncludedValues(targets)
+        val excludedTargets = calculateExcludedValues(targets)
 
         return ProjectViewTargetsSection(includedTargets, excludedTargets)
     }
@@ -50,23 +51,30 @@ object ProjectViewCLiOptionsProvider {
     private fun toDirectoriesSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewDirectoriesSection? =
             projectViewCliOptions?.directories?.let(::toDirectoriesSectionNotNull)
 
-    private fun toDirectoriesSectionNotNull(directories: List<String>?): ProjectViewDirectoriesSection {
-        val includedDirectories = calculateIncludedTargets(directories)
-        val excludedDirectories = calculateExcludedTargets(directories)
+    private fun toDirectoriesSectionNotNull(directories: List<String>): ProjectViewDirectoriesSection {
+        val includedDirectories = calculateIncludedDirs(directories)
+        val excludedDirectories = calculateExcludedDirs(directories)
 
         return ProjectViewDirectoriesSection(includedDirectories, excludedDirectories)
     }
 
-    private fun calculateIncludedTargets(targets: List<String>?): List<BuildTargetIdentifier> =
-            targets.orEmpty()
-                    .filterNot { it.startsWith(EXCLUDED_TARGET_PREFIX) }
+    private fun calculateIncludedValues(targets: List<String>): List<BuildTargetIdentifier> =
+            targets.filterNot { it.startsWith(EXCLUDED_TARGET_PREFIX) }
                     .map(::BuildTargetIdentifier)
 
-    private fun calculateExcludedTargets(targets: List<String>?): List<BuildTargetIdentifier> =
-            targets.orEmpty()
-                    .filter { it.startsWith(EXCLUDED_TARGET_PREFIX) }
+    private fun calculateExcludedValues(targets: List<String>): List<BuildTargetIdentifier> =
+            targets.filter { it.startsWith(EXCLUDED_TARGET_PREFIX) }
                     .map { it.drop(1) }
                     .map(::BuildTargetIdentifier)
+
+    private fun calculateIncludedDirs(targets: List<String>): List<Path> =
+            targets.filterNot { it.startsWith(EXCLUDED_TARGET_PREFIX) }
+                    .map(::Path)
+
+    private fun calculateExcludedDirs(targets: List<String>): List<Path> =
+            targets.filter { it.startsWith(EXCLUDED_TARGET_PREFIX) }
+                    .map { it.drop(1) }
+                    .map(::Path)
 
     private fun toDebuggerAddressSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewDebuggerAddressSection? =
             projectViewCliOptions?.debuggerAddress?.let(::ProjectViewDebuggerAddressSection)

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptions.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptions.kt
@@ -13,6 +13,8 @@ data class ProjectViewCliOptions internal constructor(
         val debuggerAddress: String?,
         val targets: List<String>?,
         val buildFlags: List<String>?,
+        val directories: List<String>?,
+        val deriveTargetsFlag: Boolean?
 )
 
 data class CliOptions internal constructor(

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptions.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptions.kt
@@ -14,7 +14,7 @@ data class ProjectViewCliOptions internal constructor(
         val targets: List<String>?,
         val buildFlags: List<String>?,
         val directories: List<String>?,
-        val deriveTargetsFlag: Boolean?
+        val deriveTargetsFromDirectories: Boolean?
 )
 
 data class CliOptions internal constructor(

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.kt
@@ -150,6 +150,8 @@ class CliOptionsProvider(private val args: Array<String>) {
                 debuggerAddress = debuggerAddress(cmd),
                 targets = targets(cmd),
                 buildFlags = buildFlags(cmd),
+                directories = directories(cmd),
+                deriveTargetsFlag = deriveTargetsFlag(cmd)
             )
         else null
 
@@ -158,7 +160,9 @@ class CliOptionsProvider(private val args: Array<String>) {
                 cmd.hasOption(JAVA_PATH_SHORT_OPT) or
                 cmd.hasOption(BAZEL_PATH_SHORT_OPT) or
                 cmd.hasOption(DEBUGGER_ADDRESS_SHORT_OPT) or
-                cmd.hasOption(BUILD_FLAGS_SHORT_OPT)
+                cmd.hasOption(BUILD_FLAGS_SHORT_OPT) or
+                cmd.hasOption(DIRECTORIES_SHORT_OPT) or
+                cmd.hasOption(DERIVE_TARGETS_FLAG_SHORT_OPT)
 
     private fun javaPath(cmd: CommandLine): Path? = getOptionValueAndMapToAbsolutePath(cmd, JAVA_PATH_SHORT_OPT)
 
@@ -171,11 +175,15 @@ class CliOptionsProvider(private val args: Array<String>) {
 
     private fun debuggerAddress(cmd: CommandLine): String? = cmd.getOptionValue(DEBUGGER_ADDRESS_SHORT_OPT)
 
+    private fun directories(cmd: CommandLine): List<String>? = cmd.getOptionValues(DIRECTORIES_SHORT_OPT)?.toList()
+
     private fun targets(cmd: CommandLine): List<String>? = cmd.getOptionValues(TARGETS_SHORT_OPT)?.toList()
 
     private fun buildFlags(cmd: CommandLine): List<String>? = cmd.getOptionValues(BUILD_FLAGS_SHORT_OPT)?.toList()
 
     private fun calculateCurrentAbsoluteDirectory(): Path = Paths.get("").toAbsolutePath()
+
+    private fun deriveTargetsFlag(cmd: CommandLine): Boolean = cmd.getOptionValue(DERIVE_TARGETS_FLAG_SHORT_OPT).toBoolean()
 
     companion object {
         private const val HELP_SHORT_OPT = "h"
@@ -186,6 +194,8 @@ class CliOptionsProvider(private val args: Array<String>) {
         private const val BAZEL_PATH_SHORT_OPT = "b"
         private const val DEBUGGER_ADDRESS_SHORT_OPT = "x"
         private const val JAVA_PATH_SHORT_OPT = "j"
+        private const val DIRECTORIES_SHORT_OPT = "r"
+        private const val DERIVE_TARGETS_FLAG_SHORT_OPT = "v"
 
         const val INSTALLER_BINARY_NAME = "bazelbsp-install"
     }

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.kt
@@ -108,14 +108,14 @@ class CliOptionsProvider(private val args: Array<String>) {
             .build()
         cliParserOptions.addOption(directoriesOption)
 
-        val deriveTargetsFlagOption = Option.builder(DERIVE_TARGETS_FLAG_SHORT_OPT)
+        val deriveTargetsFromDirectoriesOption = Option.builder(DERIVE_TARGETS_FLAG_SHORT_OPT)
             .longOpt("derive_targets_from_directories")
             .desc(
                     "Add derive_targets_from_directories to the generated project view file, you can read more about it here: " +
                             "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#derive_targets_from_directories."
             )
             .build()
-        cliParserOptions.addOption(deriveTargetsFlagOption)
+        cliParserOptions.addOption(deriveTargetsFromDirectoriesOption)
     }
 
     fun getOptions(): Try<CliOptions> {

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.kt
@@ -98,25 +98,25 @@ class CliOptionsProvider(private val args: Array<String>) {
         cliParserOptions.addOption(javaPathOption)
 
         val directoriesOption = Option.builder(DIRECTORIES_SHORT_OPT)
-                .longOpt("directories")
-                .hasArg()
-                .argName("directories")
-                .desc(
-                        "Add directories to the generated project view file, you can read more about it here: " +
-                                "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#directories."
-                )
-                .build()
+            .longOpt("directories")
+            .hasArgs()
+            .argName("directories")
+            .desc(
+                    "Add directories to the generated project view file, you can read more about it here: " +
+                            "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#directories."
+            )
+            .build()
         cliParserOptions.addOption(directoriesOption)
 
         val deriveTargetsFlagOption = Option.builder(DERIVE_TARGETS_FLAG_SHORT_OPT)
-                .longOpt("derive_targets_from_directories")
-                .hasArg()
-                .argName("derive_targets_from_directories")
-                .desc(
-                        "Add derive_targets_from_directories to the generated project view file, you can read more about it here: " +
-                                "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#derive_targets_from_directories."
-                )
-                .build()
+            .longOpt("derive_targets_from_directories")
+            .hasArg()
+            .argName("derive_targets")
+            .desc(
+                    "Add derive_targets_from_directories to the generated project view file, you can read more about it here: " +
+                            "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#derive_targets_from_directories."
+            )
+            .build()
         cliParserOptions.addOption(deriveTargetsFlagOption)
     }
 
@@ -197,13 +197,13 @@ class CliOptionsProvider(private val args: Array<String>) {
 
     private fun debuggerAddress(cmd: CommandLine): String? = cmd.getOptionValue(DEBUGGER_ADDRESS_SHORT_OPT)
 
-    private fun directories(cmd: CommandLine): List<String>? = cmd.getOptionValues(DIRECTORIES_SHORT_OPT)?.toList()
-
     private fun targets(cmd: CommandLine): List<String>? = cmd.getOptionValues(TARGETS_SHORT_OPT)?.toList()
 
     private fun buildFlags(cmd: CommandLine): List<String>? = cmd.getOptionValues(BUILD_FLAGS_SHORT_OPT)?.toList()
 
     private fun calculateCurrentAbsoluteDirectory(): Path = Paths.get("").toAbsolutePath()
+
+    private fun directories(cmd: CommandLine): List<String>? = cmd.getOptionValues(DIRECTORIES_SHORT_OPT)?.toList()
 
     private fun deriveTargetsFlag(cmd: CommandLine): Boolean = cmd.getOptionValue(DERIVE_TARGETS_FLAG_SHORT_OPT).toBoolean()
 

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.kt
@@ -96,6 +96,28 @@ class CliOptionsProvider(private val args: Array<String>) {
             )
             .build()
         cliParserOptions.addOption(javaPathOption)
+
+        val directoriesOption = Option.builder(DIRECTORIES_SHORT_OPT)
+                .longOpt("directories")
+                .hasArg()
+                .argName("directories")
+                .desc(
+                        "Add directories to the generated project view file, you can read more about it here: " +
+                                "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#directories."
+                )
+                .build()
+        cliParserOptions.addOption(directoriesOption)
+
+        val deriveTargetsFlagOption = Option.builder(DERIVE_TARGETS_FLAG_SHORT_OPT)
+                .longOpt("derive_targets_from_directories")
+                .hasArg()
+                .argName("derive_targets_from_directories")
+                .desc(
+                        "Add derive_targets_from_directories to the generated project view file, you can read more about it here: " +
+                                "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#derive_targets_from_directories."
+                )
+                .build()
+        cliParserOptions.addOption(deriveTargetsFlagOption)
     }
 
     fun getOptions(): Try<CliOptions> {
@@ -133,7 +155,7 @@ class CliOptionsProvider(private val args: Array<String>) {
             INSTALLER_BINARY_NAME,
             null,
             cliParserOptions,
-            "If any generation flag (-b, -f, -j, -t, -x) " +
+            "If any generation flag (-b, -f, -j, -t, -x, -r, -v) " +
                     "is used, the installer will generate a new project view file with these sections. " +
                     "If --project_view_file (-p) flag is used as well, the new project view file " +
                     "will be created under this location (it will override the existing file if exists). " +

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.kt
@@ -110,8 +110,6 @@ class CliOptionsProvider(private val args: Array<String>) {
 
         val deriveTargetsFlagOption = Option.builder(DERIVE_TARGETS_FLAG_SHORT_OPT)
             .longOpt("derive_targets_from_directories")
-            .hasArg()
-            .argName("derive_targets")
             .desc(
                     "Add derive_targets_from_directories to the generated project view file, you can read more about it here: " +
                             "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#derive_targets_from_directories."
@@ -173,7 +171,7 @@ class CliOptionsProvider(private val args: Array<String>) {
                 targets = targets(cmd),
                 buildFlags = buildFlags(cmd),
                 directories = directories(cmd),
-                deriveTargetsFlag = deriveTargetsFlag(cmd)
+                deriveTargetsFromDirectories = deriveTargetsFlag(cmd)
             )
         else null
 
@@ -205,7 +203,7 @@ class CliOptionsProvider(private val args: Array<String>) {
 
     private fun directories(cmd: CommandLine): List<String>? = cmd.getOptionValues(DIRECTORIES_SHORT_OPT)?.toList()
 
-    private fun deriveTargetsFlag(cmd: CommandLine): Boolean = cmd.getOptionValue(DERIVE_TARGETS_FLAG_SHORT_OPT).toBoolean()
+    private fun deriveTargetsFlag(cmd: CommandLine): Boolean = cmd.hasOption(DERIVE_TARGETS_FLAG_SHORT_OPT)
 
     companion object {
         private const val HELP_SHORT_OPT = "h"

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.kt
@@ -148,7 +148,7 @@ class CliOptionsProvider(private val args: Array<String>) {
 
     private fun printHelp() {
         val formatter = HelpFormatter()
-        formatter.width = 150
+        formatter.width = 160
         formatter.printHelp(
             INSTALLER_BINARY_NAME,
             null,

--- a/install/src/test/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProviderTest.kt
+++ b/install/src/test/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProviderTest.kt
@@ -405,6 +405,78 @@ class CliOptionsProviderTest {
             }
         }
 
+        @Nested
+        @DisplayName("cliOptions.projectViewCliOptions.directoriesOption test")
+        inner class DirectoriesOptionTest {
+            @Test
+            fun `should return success if directories are specified`() {
+                // given
+                val args = arrayOf(
+                        "-r",
+                        "included_dir1",
+                        "included_dir2",
+                        "-excluded_dir3"
+                )
+
+                // when
+                val provider = CliOptionsProvider(args)
+                val cliOptionsTry = provider.getOptions()
+
+                // then
+                cliOptionsTry.isSuccess shouldBe true
+                val cliOptions = cliOptionsTry.get()
+
+                val expectedDirs = listOf(
+                        "included_dir1",
+                        "included_dir2",
+                        "-excluded_dir3",
+                )
+                cliOptions.projectViewCliOptions?.directories shouldBe expectedDirs
+            }
+        }
+
+        @Nested
+        @DisplayName("cliOptions.projectViewCliOptions.deriveTargetsFlagOption test")
+        inner class DeriveTargetsFlagOptionTest {
+            @Test
+            fun `should return success if deriveTargetsFlag is specified and true`() {
+                // given
+                val args = arrayOf(
+                        "-v",
+                        "true",
+                )
+
+                // when
+                val provider = CliOptionsProvider(args)
+                val cliOptionsTry = provider.getOptions()
+
+                // then
+                cliOptionsTry.isSuccess shouldBe true
+                val cliOptions = cliOptionsTry.get()
+
+                cliOptions.projectViewCliOptions?.deriveTargetsFlag shouldBe true
+            }
+
+            @Test
+            fun `should return success if deriveTargetsFlag is specified and false`() {
+                // given
+                val args = arrayOf(
+                        "-v",
+                        "false",
+                )
+
+                // when
+                val provider = CliOptionsProvider(args)
+                val cliOptionsTry = provider.getOptions()
+
+                // then
+                cliOptionsTry.isSuccess shouldBe true
+                val cliOptions = cliOptionsTry.get()
+
+                cliOptions.projectViewCliOptions?.deriveTargetsFlag shouldBe false
+            }
+        }
+
         @Test
         fun `should return success if all flags are specified`() {
             // given
@@ -428,7 +500,13 @@ class CliOptionsProviderTest {
                     "-f",
                     "--build_flag1=value1",
                     "--build_flag1=value2",
-                    "--build_flag1=value3"
+                    "--build_flag1=value3",
+                    "-r",
+                    "included_dir1",
+                    "included_dir2",
+                    "-excluded_dir3",
+                    "-v",
+                    "true",
             )
 
             // when
@@ -466,6 +544,15 @@ class CliOptionsProviderTest {
 
             val expectedBuildFlags = listOf("--build_flag1=value1", "--build_flag1=value2", "--build_flag1=value3")
             cliOptions.projectViewCliOptions?.buildFlags shouldBe expectedBuildFlags
+
+            val expectedDirs = listOf(
+                    "included_dir1",
+                    "included_dir2",
+                    "-excluded_dir3",
+            )
+            cliOptions.projectViewCliOptions?.directories shouldBe expectedDirs
+
+            cliOptions.projectViewCliOptions?.deriveTargetsFlag shouldBe true
         }
 
         @Test
@@ -504,5 +591,6 @@ class CliOptionsProviderTest {
             val expectedBuildFlags = listOf("--build_flag1=value1", "--build_flag1=value2", "--build_flag1=value3")
             cliOptions.projectViewCliOptions?.buildFlags shouldBe expectedBuildFlags
         }
+
     }
 }

--- a/install/src/test/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProviderTest.kt
+++ b/install/src/test/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProviderTest.kt
@@ -439,7 +439,7 @@ class CliOptionsProviderTest {
         @DisplayName("cliOptions.projectViewCliOptions.deriveTargetsFlagOption test")
         inner class DeriveTargetsFlagOptionTest {
             @Test
-            fun `should return success if deriveTargetsFlag is specified and true`() {
+            fun `should return success if deriveTargetsFlag is specified`() {
                 // given
                 val args = arrayOf(
                         "-v"
@@ -454,6 +454,22 @@ class CliOptionsProviderTest {
                 val cliOptions = cliOptionsTry.get()
 
                 cliOptions.projectViewCliOptions?.deriveTargetsFromDirectories shouldBe true
+            }
+
+            @Test
+            fun `should return success if deriveTargetsFlag is not specified`() {
+                // given
+                val args = emptyArray<String>()
+
+                // when
+                val provider = CliOptionsProvider(args)
+                val cliOptionsTry = provider.getOptions()
+
+                // then
+                cliOptionsTry.isSuccess shouldBe true
+                val cliOptions = cliOptionsTry.get()
+
+                cliOptions.projectViewCliOptions?.deriveTargetsFromDirectories shouldBe null
             }
         }
 

--- a/install/src/test/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProviderTest.kt
+++ b/install/src/test/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProviderTest.kt
@@ -442,8 +442,7 @@ class CliOptionsProviderTest {
             fun `should return success if deriveTargetsFlag is specified and true`() {
                 // given
                 val args = arrayOf(
-                        "-v",
-                        "true",
+                        "-v"
                 )
 
                 // when
@@ -454,26 +453,7 @@ class CliOptionsProviderTest {
                 cliOptionsTry.isSuccess shouldBe true
                 val cliOptions = cliOptionsTry.get()
 
-                cliOptions.projectViewCliOptions?.deriveTargetsFlag shouldBe true
-            }
-
-            @Test
-            fun `should return success if deriveTargetsFlag is specified and false`() {
-                // given
-                val args = arrayOf(
-                        "-v",
-                        "false",
-                )
-
-                // when
-                val provider = CliOptionsProvider(args)
-                val cliOptionsTry = provider.getOptions()
-
-                // then
-                cliOptionsTry.isSuccess shouldBe true
-                val cliOptions = cliOptionsTry.get()
-
-                cliOptions.projectViewCliOptions?.deriveTargetsFlag shouldBe false
+                cliOptions.projectViewCliOptions?.deriveTargetsFromDirectories shouldBe true
             }
         }
 
@@ -505,8 +485,7 @@ class CliOptionsProviderTest {
                     "included_dir1",
                     "included_dir2",
                     "-excluded_dir3",
-                    "-v",
-                    "true",
+                    "-v"
             )
 
             // when
@@ -552,7 +531,7 @@ class CliOptionsProviderTest {
             )
             cliOptions.projectViewCliOptions?.directories shouldBe expectedDirs
 
-            cliOptions.projectViewCliOptions?.deriveTargetsFlag shouldBe true
+            cliOptions.projectViewCliOptions?.deriveTargetsFromDirectories shouldBe true
         }
 
         @Test


### PR DESCRIPTION
Added parsing directories and derive_targets_from_directories section from project view file and mapping those into targets

---

https://youtrack.jetbrains.com/issue/BAZEL-33
https://youtrack.jetbrains.com/issue/BAZEL-55