### PR TITLE
[change] fix scala version regex

### DIFF
--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaSdkResolver.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaSdkResolver.java
@@ -22,7 +22,7 @@ public class ScalaSdkResolver {
       };
   private final BazelPathsResolver bazelPathsResolver;
   private final Pattern VERSION_PATTERN =
-      Pattern.compile("scala-(?:library|compiler|reflect)-(.*)\\.jar");
+      Pattern.compile("scala-(?:library|compiler|reflect)-([.\\d]+)\\.jar");
 
   public ScalaSdkResolver(BazelPathsResolver bazelPathsResolver) {
     this.bazelPathsResolver = bazelPathsResolver;


### PR DESCRIPTION
Otherwise it catches strange jars like scala-library-indexing_interface_2.12-1.1.0.jar - blocks importing google's bazel plugin