### PR TITLE
[change] cache uris and paths in BazelPathsResolver

### DIFF
--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/BazelProjectMapper.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/BazelProjectMapper.java
@@ -8,7 +8,6 @@ import io.vavr.collection.Seq;
 import io.vavr.collection.Set;
 import io.vavr.control.Option;
 import java.net.URI;
-import java.nio.file.Path;
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.FileLocation;
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.TargetInfo;
 import org.jetbrains.bsp.bazel.server.bsp.utils.SourceRootGuesser;
@@ -72,7 +71,7 @@ public class BazelProjectMapper {
     var directDependencies = resolveDirectDependencies(target);
     var languages = inferLanguages(target);
     var tags = targetKindResolver.resolveTags(target);
-    var baseDirectory = bazelPathsResolver.labelToDirectory(label).toUri();
+    var baseDirectory = bazelPathsResolver.labelToDirectoryUri(label);
     var sourceSet = resolveSourceSet(target);
     var resources = resolveResources(target);
 
@@ -115,7 +114,9 @@ public class BazelProjectMapper {
   private SourceSet resolveSourceSet(TargetInfo target) {
     var sources = HashSet.ofAll(target.getSourcesList()).map(bazelPathsResolver::resolve);
     var sourceRoots = sources.map(SourceRootGuesser::getSourcesRoot);
-    return new SourceSet(sources.map(Path::toUri), sourceRoots.map(Path::toUri));
+    return new SourceSet(
+        sources.map(bazelPathsResolver::resolveUri),
+        sourceRoots.map(bazelPathsResolver::resolveUri));
   }
 
   private Set<URI> resolveResources(TargetInfo target) {
@@ -125,7 +126,7 @@ public class BazelProjectMapper {
   // TODO make this feature configurable with flag in project view file
   private Seq<Module> createSyntheticModules(
       Seq<Module> modulesFromBazel, URI workspaceRoot, WorkspaceContext workspaceContext) {
-    return new IntelliJProjectTreeViewFix()
+    return new IntelliJProjectTreeViewFix(bazelPathsResolver)
         .createModules(workspaceRoot, modulesFromBazel, workspaceContext);
   }
 

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/IntelliJProjectTreeViewFix.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/IntelliJProjectTreeViewFix.java
@@ -10,7 +10,6 @@ import io.vavr.collection.Set;
 import io.vavr.control.Option;
 import java.net.URI;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import org.jetbrains.bsp.bazel.server.sync.model.Label;
@@ -21,6 +20,13 @@ import org.jetbrains.bsp.bazel.workspacecontext.TargetsSpec;
 import org.jetbrains.bsp.bazel.workspacecontext.WorkspaceContext;
 
 public class IntelliJProjectTreeViewFix {
+
+  private final BazelPathsResolver bazelPathsResolver;
+
+  public IntelliJProjectTreeViewFix(BazelPathsResolver bazelPathsResolver) {
+    this.bazelPathsResolver = bazelPathsResolver;
+  }
+
   public Seq<Module> createModules(
       URI workspaceRoot, Seq<Module> modules, WorkspaceContext workspaceContext) {
     if (isFullWorkspaceImport(workspaceContext)) {
@@ -92,7 +98,7 @@ public class IntelliJProjectTreeViewFix {
         .map(s -> stripPrefixes(s, "//"))
         .map(root::resolve)
         .filter(Files::exists)
-        .map(Path::toUri)
+        .map(bazelPathsResolver::resolveUri)
         .map(URI::toString)
         .toArray();
   }

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaSdkResolver.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaSdkResolver.java
@@ -50,7 +50,12 @@ public class ScalaSdkResolver {
     }
     var version = maybeVersions.distinct().sorted().last();
     var binaryVersion = toBinaryVersion(version);
-    var sdk = new ScalaSdk("org.scala-lang", version, binaryVersion, compilerJars.map(Path::toUri));
+    var sdk =
+        new ScalaSdk(
+            "org.scala-lang",
+            version,
+            binaryVersion,
+            compilerJars.map(bazelPathsResolver::resolveUri));
     return Option.some(sdk);
   }
 


### PR DESCRIPTION
Path resolution is the heaviest part of the whole bsp mappping process (and vavr collections). Paths.get and Path.toUri calls take a lot of time. This can be optimized. 

Check out these stats

Building project with aspect completed in 3m 30s
Reading aspect output paths completed in 593ms
Parsing aspect outputs completed in 20s
Mapping to internal model completed in 39.3s
**Collected uris in total: 4009673
Collected unique uris in total: 15665**
Saving project to local cache completed in 4s

Reduces mapping to internal model by 50% for me.