### PR TITLE
[change] added parsing for package prefixes

### DIFF
--- a/e2e/src/main/java/org/jetbrains/bsp/bazel/BazelBspLocalJdkTest.kt
+++ b/e2e/src/main/java/org/jetbrains/bsp/bazel/BazelBspLocalJdkTest.kt
@@ -21,16 +21,6 @@ object BazelBspLocalJdkTest : BazelBspTestBaseScenario() {
             "17"
         )
 
-        val rootBuildTarget = BuildTarget(
-            BuildTargetIdentifier("bsp-workspace-root"),
-            emptyList(),
-            emptyList(),
-            emptyList(),
-            BuildTargetCapabilities(false, false, false, false)
-        )
-        rootBuildTarget.displayName = "bsp-workspace-root"
-        rootBuildTarget.baseDirectory = "file://\$WORKSPACE/"
-
         val exampleExampleBuildTarget = BuildTarget(
             BuildTargetIdentifier("//example:example"),
             listOf("application"),
@@ -44,7 +34,7 @@ object BazelBspLocalJdkTest : BazelBspTestBaseScenario() {
         exampleExampleBuildTarget.dataKind = BuildTargetDataKind.JVM
 
         val workspaceBuildTargetsResult = WorkspaceBuildTargetsResult(
-            listOf(rootBuildTarget, exampleExampleBuildTarget)
+            listOf(exampleExampleBuildTarget)
         )
         return BazelBspTestScenarioStep("workspace build targets") {
             testClient.testWorkspaceTargets(

--- a/e2e/src/main/java/org/jetbrains/bsp/bazel/BazelBspRemoteJdkTest.kt
+++ b/e2e/src/main/java/org/jetbrains/bsp/bazel/BazelBspRemoteJdkTest.kt
@@ -21,16 +21,6 @@ object BazelBspRemoteJdkTest : BazelBspTestBaseScenario() {
             "11"
         )
 
-        val rootBuildTarget = BuildTarget(
-            BuildTargetIdentifier("bsp-workspace-root"),
-            emptyList(),
-            emptyList(),
-            emptyList(),
-            BuildTargetCapabilities(false, false, false, false)
-        )
-        rootBuildTarget.displayName = "bsp-workspace-root"
-        rootBuildTarget.baseDirectory = "file://\$WORKSPACE/"
-
         val exampleExampleBuildTarget = BuildTarget(
             BuildTargetIdentifier("//example:example"),
             listOf("application"),
@@ -44,7 +34,7 @@ object BazelBspRemoteJdkTest : BazelBspTestBaseScenario() {
         exampleExampleBuildTarget.dataKind = BuildTargetDataKind.JVM
 
         val workspaceBuildTargetsResult = WorkspaceBuildTargetsResult(
-            listOf(rootBuildTarget, exampleExampleBuildTarget)
+            listOf(exampleExampleBuildTarget)
         )
         return BazelBspTestScenarioStep("workspace build targets") {
             testClient.testWorkspaceTargets(

--- a/e2e/src/main/java/org/jetbrains/bsp/bazel/BazelBspSampleRepoTest.kt
+++ b/e2e/src/main/java/org/jetbrains/bsp/bazel/BazelBspSampleRepoTest.kt
@@ -84,7 +84,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//target_without_jvm_flags:binary"),
             listOf(targetWithoutJvmFlagsExampleScala)
         )
-        targetWithoutJvmFlagsSources.roots = listOf("file://\$WORKSPACE/target_without_jvm_flags/")
+        targetWithoutJvmFlagsSources.roots = listOf("file://\$WORKSPACE/")
 
         val targetWithoutArgsExampleScala = SourceItem(
             "file://\$WORKSPACE/target_without_args/Example.scala", SourceItemKind.FILE, false
@@ -93,7 +93,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//target_without_args:binary"),
             listOf(targetWithoutArgsExampleScala)
         )
-        targetWithoutArgsSources.roots = listOf("file://\$WORKSPACE/target_without_args/")
+        targetWithoutArgsSources.roots = listOf("file://\$WORKSPACE/")
 
         val targetWithoutMainClassExampleScala = SourceItem(
             "file://\$WORKSPACE/target_without_main_class/Example.scala",
@@ -104,7 +104,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//target_without_main_class:library"),
             listOf(targetWithoutMainClassExampleScala)
         )
-        targetWithoutMainClassSources.roots = listOf("file://\$WORKSPACE/target_without_main_class/")
+        targetWithoutMainClassSources.roots = listOf("file://\$WORKSPACE/")
 
         val targetWithResourcesJavaBinaryJava = SourceItem(
             "file://\$WORKSPACE/target_with_resources/JavaBinary.java", SourceItemKind.FILE, false
@@ -113,7 +113,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//target_with_resources:java_binary"),
             listOf(targetWithResourcesJavaBinaryJava)
         )
-        targetWithResourcesSources.roots = listOf("file://\$WORKSPACE/target_with_resources/")
+        targetWithResourcesSources.roots = listOf("file://\$WORKSPACE/")
 
         val targetWithDependencyJavaBinaryJava = SourceItem(
             "file://\$WORKSPACE/target_with_dependency/JavaBinary.java", SourceItemKind.FILE, false
@@ -122,7 +122,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//target_with_dependency:java_binary"),
             listOf(targetWithDependencyJavaBinaryJava)
         )
-        targetWithDependencySources.roots = listOf("file://\$WORKSPACE/target_with_dependency/")
+        targetWithDependencySources.roots = listOf("file://\$WORKSPACE/")
 
         val scalaTargetsScalaBinaryScala = SourceItem(
             "file://\$WORKSPACE/scala_targets/ScalaBinary.scala", SourceItemKind.FILE, false
@@ -131,7 +131,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//scala_targets:scala_binary"),
             listOf(scalaTargetsScalaBinaryScala)
         )
-        scalaTargetsScalaBinarySources.roots = listOf("file://\$WORKSPACE/scala_targets/")
+        scalaTargetsScalaBinarySources.roots = listOf("file://\$WORKSPACE/")
 
         val scalaTargetsScalaTestScala = SourceItem(
             "file://\$WORKSPACE/scala_targets/ScalaTest.scala", SourceItemKind.FILE, false
@@ -140,7 +140,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//scala_targets:scala_test"),
             listOf(scalaTargetsScalaTestScala)
         )
-        scalaTargetsScalaTestSources.roots = listOf("file://\$WORKSPACE/scala_targets/")
+        scalaTargetsScalaTestSources.roots = listOf("file://\$WORKSPACE/")
 
         val javaTargetsJavaBinaryJava = SourceItem(
             "file://\$WORKSPACE/java_targets/JavaBinary.java", SourceItemKind.FILE, false
@@ -149,7 +149,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//java_targets:java_binary"),
             listOf(javaTargetsJavaBinaryJava)
         )
-        javaTargetsJavaBinarySources.roots = listOf("file://\$WORKSPACE/java_targets/")
+        javaTargetsJavaBinarySources.roots = listOf("file://\$WORKSPACE/")
 
         val javaTargetsJavaLibraryJava = SourceItem(
             "file://\$WORKSPACE/java_targets/JavaLibrary.java", SourceItemKind.FILE, false
@@ -158,7 +158,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//java_targets:java_library"),
             listOf(javaTargetsJavaLibraryJava)
         )
-        javaTargetsJavaLibrarySources.roots = listOf("file://\$WORKSPACE/java_targets/")
+        javaTargetsJavaLibrarySources.roots = listOf("file://\$WORKSPACE/")
 
         val javaTargetsSubpackageJavaLibraryJava = SourceItem(
             "file://\$WORKSPACE/java_targets/subpackage/JavaLibrary2.java",
@@ -169,10 +169,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//java_targets/subpackage:java_library"),
             listOf(javaTargetsSubpackageJavaLibraryJava)
         )
-        javaTargetsSubpackageJavaLibrarySources.roots = listOf("file://\$WORKSPACE/java_targets/subpackage/")
-
-        val bspWorkspaceRoot = SourcesItem(BuildTargetIdentifier("bsp-workspace-root"), emptyList())
-        bspWorkspaceRoot.roots = emptyList()
+        javaTargetsSubpackageJavaLibrarySources.roots = listOf("file://\$WORKSPACE/")
 
         val javaTargetsJavaLibraryExportedSources = SourcesItem(
             BuildTargetIdentifier("//java_targets:java_library_exported"), emptyList()
@@ -186,7 +183,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//manual_target:java_library"),
             listOf(manualTargetTestJavaFile)
         )
-        manualTargetTestJavaFileSources.roots = listOf("file://\$WORKSPACE/manual_target/")
+        manualTargetTestJavaFileSources.roots = listOf("file://\$WORKSPACE/")
 
         val manualTargetTestScalaFile = SourceItem(
             "file://\$WORKSPACE/manual_target/TestScalaFile.scala", SourceItemKind.FILE, false
@@ -195,7 +192,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//manual_target:scala_library"),
             listOf(manualTargetTestScalaFile)
         )
-        manualTargetTestScalaFileSources.roots = listOf("file://\$WORKSPACE/manual_target/")
+        manualTargetTestScalaFileSources.roots = listOf("file://\$WORKSPACE/")
 
         val manualTargetTestJavaTest =
             SourceItem("file://\$WORKSPACE/manual_target/JavaTest.java", SourceItemKind.FILE, false)
@@ -203,7 +200,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//manual_target:java_test"),
             listOf(manualTargetTestJavaTest)
         )
-        manualTargetTestJavaTestSources.roots = listOf("file://\$WORKSPACE/manual_target/")
+        manualTargetTestJavaTestSources.roots = listOf("file://\$WORKSPACE/")
 
         val manualTargetTestScalaTest = SourceItem(
             "file://\$WORKSPACE/manual_target/ScalaTest.scala", SourceItemKind.FILE, false
@@ -212,7 +209,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//manual_target:scala_test"),
             listOf(manualTargetTestScalaTest)
         )
-        manualTargetTestScalaTestSources.roots = listOf("file://\$WORKSPACE/manual_target/")
+        manualTargetTestScalaTestSources.roots = listOf("file://\$WORKSPACE/")
 
         val manualTargetTestJavaBinary = SourceItem(
             "file://\$WORKSPACE/manual_target/TestJavaBinary.java", SourceItemKind.FILE, false
@@ -221,7 +218,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//manual_target:java_binary"),
             listOf(manualTargetTestJavaBinary)
         )
-        manualTargetTestJavaBinarySources.roots = listOf("file://\$WORKSPACE/manual_target/")
+        manualTargetTestJavaBinarySources.roots = listOf("file://\$WORKSPACE/")
 
         val manualTargetTestScalaBinary = SourceItem(
             "file://\$WORKSPACE/manual_target/TestScalaBinary.scala", SourceItemKind.FILE, false
@@ -230,7 +227,7 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
             BuildTargetIdentifier("//manual_target:scala_binary"),
             listOf(manualTargetTestScalaBinary)
         )
-        manualTargetTestScalaBinarySources.roots = listOf("file://\$WORKSPACE/manual_target/")
+        manualTargetTestScalaBinarySources.roots = listOf("file://\$WORKSPACE/")
 
         val sourcesParams = SourcesParams(expectedTargetIdentifiers())
         val expectedSourcesResult = SourcesResult(
@@ -245,7 +242,6 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
                 javaTargetsJavaBinarySources,
                 javaTargetsJavaLibrarySources,
                 javaTargetsSubpackageJavaLibrarySources,
-                bspWorkspaceRoot,
                 javaTargetsJavaLibraryExportedSources,
                 manualTargetTestJavaFileSources,
                 manualTargetTestScalaFileSources,
@@ -261,9 +257,6 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
     }
 
     private fun resourcesResults(): BazelBspTestScenarioStep {
-        val bspWorkspaceRoot = ResourcesItem(
-            BuildTargetIdentifier("bsp-workspace-root"), listOf("file://\$WORKSPACE/")
-        )
         val targetWithResources = ResourcesItem(
             BuildTargetIdentifier("//target_with_resources:java_binary"),
             listOf(
@@ -311,7 +304,6 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
 
         val expectedResourcesResult = ResourcesResult(
             listOf(
-                bspWorkspaceRoot,
                 targetWithResources,
                 javaTargetsSubpackageJavaLibrary,
                 javaTargetsJavaBinary,
@@ -494,7 +486,6 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
         val javaTargetsJavaLibraryExported = DependencySourcesItem(
             BuildTargetIdentifier("//java_targets:java_library_exported"), emptyList()
         )
-        val bspWorkspaceRoot = DependencySourcesItem(BuildTargetIdentifier("bsp-workspace-root"), emptyList())
         val manualTargetJavaLibrary = DependencySourcesItem(
             BuildTargetIdentifier("//manual_target:java_library"), emptyList()
         )
@@ -526,7 +517,6 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
                 targetWithoutJvmFlagsBinary,
                 targetWithoutMainClassLibrary,
                 javaTargetsJavaLibraryExported,
-                bspWorkspaceRoot,
                 manualTargetJavaLibrary,
                 manualTargetScalaLibrary,
                 manualTargetJavaBinary,
@@ -957,16 +947,6 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
         javaTargetsJavaLibraryExported.displayName = "//java_targets:java_library_exported"
         javaTargetsJavaLibraryExported.baseDirectory = "file://\$WORKSPACE/java_targets/"
 
-        val bspWorkspaceRoot = BuildTarget(
-            BuildTargetIdentifier("bsp-workspace-root"),
-            emptyList(),
-            emptyList(),
-            emptyList(),
-            BuildTargetCapabilities(false, false, false, false)
-        )
-        bspWorkspaceRoot.displayName = "bsp-workspace-root"
-        bspWorkspaceRoot.baseDirectory = "file://\$WORKSPACE/"
-
         val manualScalaBuildTarget = ScalaBuildTarget(
             "org.scala-lang",
             "2.12.14",
@@ -1058,7 +1038,6 @@ object BazelBspSampleRepoTest : BazelBspTestBaseScenario() {
                 scalaTargetsScalaTest,
                 targetWithResourcesJavaBinary,
                 javaTargetsJavaLibraryExported,
-                bspWorkspaceRoot,
                 manualTargetJavaLibrary,
                 manualTargetScalaLibrary,
                 manualTargetJavaBinary,

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/BazelProjectMapper.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/BazelProjectMapper.java
@@ -5,9 +5,9 @@ import io.vavr.control.Option;
 import java.net.URI;
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.FileLocation;
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.TargetInfo;
-import org.jetbrains.bsp.bazel.server.bsp.utils.SourceRootGuesser;
 import org.jetbrains.bsp.bazel.server.sync.dependencytree.DependencyTree;
 import org.jetbrains.bsp.bazel.server.sync.languages.LanguageData;
+import org.jetbrains.bsp.bazel.server.sync.languages.LanguagePlugin;
 import org.jetbrains.bsp.bazel.server.sync.languages.LanguagePluginsService;
 import org.jetbrains.bsp.bazel.server.sync.model.Label;
 import org.jetbrains.bsp.bazel.server.sync.model.Language;
@@ -72,11 +72,12 @@ public class BazelProjectMapper {
     var languages = inferLanguages(target);
     var tags = targetKindResolver.resolveTags(target);
     var baseDirectory = bazelPathsResolver.labelToDirectoryUri(label);
-    var sourceSet = resolveSourceSet(target);
-    var resources = resolveResources(target);
 
     var languagePlugin = languagePluginsService.getPlugin(languages);
     var languageData = (Option<LanguageData>) languagePlugin.resolveModule(target);
+
+    var sourceSet = resolveSourceSet(target, languagePlugin);
+    var resources = resolveResources(target);
 
     var sourceDependencies = languagePlugin.dependencySources(target, dependencyTree);
 
@@ -111,9 +112,10 @@ public class BazelProjectMapper {
     return language.getExtensions().exists(ext -> file.getRelativePath().endsWith(ext));
   }
 
-  private SourceSet resolveSourceSet(TargetInfo target) {
+  private SourceSet resolveSourceSet(TargetInfo target, LanguagePlugin<?> languagePlugin) {
     var sources = HashSet.ofAll(target.getSourcesList()).map(bazelPathsResolver::resolve);
-    var sourceRoots = sources.map(SourceRootGuesser::getSourcesRoot);
+    var sourceRoots = sources.flatMap(languagePlugin::calculateSourceRoot);
+
     return new SourceSet(
         sources.map(bazelPathsResolver::resolveUri),
         sourceRoots.map(bazelPathsResolver::resolveUri));

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/EmptyLanguagePlugin.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/EmptyLanguagePlugin.java
@@ -2,6 +2,7 @@ package org.jetbrains.bsp.bazel.server.sync.languages;
 
 import ch.epfl.scala.bsp4j.BuildTarget;
 import io.vavr.control.Option;
+import java.nio.file.Path;
 import org.jetbrains.bsp.bazel.info.BspTargetInfo;
 
 public class EmptyLanguagePlugin extends LanguagePlugin<LanguageData> {
@@ -12,4 +13,9 @@ public class EmptyLanguagePlugin extends LanguagePlugin<LanguageData> {
 
   @Override
   protected void applyModuleData(LanguageData moduleData, BuildTarget buildTarget) {}
+
+  @Override
+  public Option<Path> calculateSourceRoot(Path source) {
+    return Option.none();
+  }
 }

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/JVMLanguagePluginParser.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/JVMLanguagePluginParser.java
@@ -1,0 +1,68 @@
+package org.jetbrains.bsp.bazel.server.sync.languages;
+
+import io.vavr.control.Option;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jetbrains.bsp.bazel.server.bsp.utils.SourceRootGuesser;
+
+public class JVMLanguagePluginParser {
+  private static final Pattern PACKAGE_PATTERN = Pattern.compile("^\\s*package\\s+([\\w\\.]+)");
+
+  public JVMLanguagePluginParser() {}
+
+  public static Option<Path> calculateJVMSourceRoot(Path source, boolean multipleLines) {
+    String sourcePackage = findPackage(source, multipleLines);
+
+    if (sourcePackage == null) {
+      return Option.some(SourceRootGuesser.getSourcesRoot(source));
+    }
+    Path sourcePackagePath = Paths.get(sourcePackage.replace(".", "/"));
+
+    return Option.some(
+        Paths.get("/")
+            .resolve(
+                source.subpath(0, source.getNameCount() - sourcePackagePath.getNameCount() - 1)));
+  }
+
+  private static String findPackage(Path source, boolean multipleLines) {
+    List<String> packages;
+    File sourceFile = new File(String.valueOf(source));
+    try {
+      BufferedReader reader = new BufferedReader(new FileReader(sourceFile));
+      packages = findPackages(reader);
+      reader.close();
+    } catch (IOException e) {
+      e.printStackTrace();
+      return null;
+    }
+
+    if (!packages.isEmpty()) {
+      if (multipleLines) {
+        return String.join(".", packages);
+      } else {
+        return packages.get(0);
+      }
+    }
+    return null;
+  }
+
+  private static List<String> findPackages(BufferedReader reader) throws IOException {
+    List<String> packages = new ArrayList<>();
+    String line;
+    while ((line = reader.readLine()) != null) {
+      Matcher matcher = PACKAGE_PATTERN.matcher(line);
+      if (matcher.find()) {
+        packages.add(matcher.group(1));
+      }
+    }
+    return packages;
+  }
+}

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/LanguagePlugin.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/LanguagePlugin.java
@@ -6,6 +6,7 @@ import io.vavr.collection.Seq;
 import io.vavr.collection.Set;
 import io.vavr.control.Option;
 import java.net.URI;
+import java.nio.file.Path;
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.TargetInfo;
 import org.jetbrains.bsp.bazel.server.sync.dependencytree.DependencyTree;
 
@@ -25,4 +26,6 @@ public abstract class LanguagePlugin<T extends LanguageData> {
   }
 
   protected abstract void applyModuleData(T moduleData, BuildTarget buildTarget);
+
+  public abstract Option<Path> calculateSourceRoot(Path source);
 }

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/cpp/CppLanguagePlugin.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/cpp/CppLanguagePlugin.java
@@ -2,6 +2,7 @@ package org.jetbrains.bsp.bazel.server.sync.languages.cpp;
 
 import ch.epfl.scala.bsp4j.BuildTarget;
 import io.vavr.control.Option;
+import java.nio.file.Path;
 import org.jetbrains.bsp.bazel.info.BspTargetInfo;
 import org.jetbrains.bsp.bazel.server.sync.languages.LanguagePlugin;
 
@@ -14,4 +15,9 @@ public class CppLanguagePlugin extends LanguagePlugin<CppModule> {
 
   @Override
   public void applyModuleData(CppModule moduleData, BuildTarget buildTarget) {}
+
+  @Override
+  public Option<Path> calculateSourceRoot(Path source) {
+    return Option.none();
+  }
 }

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/java/JavaLanguagePlugin.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/java/JavaLanguagePlugin.java
@@ -13,12 +13,14 @@ import io.vavr.collection.Seq;
 import io.vavr.collection.Set;
 import io.vavr.control.Option;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.Map;
 import org.jetbrains.bsp.bazel.bazelrunner.BazelInfo;
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.JavaTargetInfo;
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.TargetInfo;
 import org.jetbrains.bsp.bazel.server.sync.BazelPathsResolver;
 import org.jetbrains.bsp.bazel.server.sync.dependencytree.DependencyTree;
+import org.jetbrains.bsp.bazel.server.sync.languages.JVMLanguagePluginParser;
 import org.jetbrains.bsp.bazel.server.sync.languages.LanguagePlugin;
 import org.jetbrains.bsp.bazel.server.sync.model.Module;
 
@@ -103,6 +105,11 @@ public class JavaLanguagePlugin extends LanguagePlugin<JavaModule> {
     JvmBuildTarget jvmBuildTarget = toJvmBuildTarget(javaModule);
     buildTarget.setDataKind(BuildTargetDataKind.JVM);
     buildTarget.setData(jvmBuildTarget);
+  }
+
+  @Override
+  public Option<Path> calculateSourceRoot(Path source) {
+    return JVMLanguagePluginParser.calculateJVMSourceRoot(source, false);
   }
 
   public JvmBuildTarget toJvmBuildTarget(JavaModule javaModule) {

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaLanguagePlugin.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaLanguagePlugin.java
@@ -16,11 +16,13 @@ import io.vavr.collection.Seq;
 import io.vavr.collection.Set;
 import io.vavr.control.Option;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.function.BiFunction;
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.TargetInfo;
 import org.jetbrains.bsp.bazel.server.sync.BazelPathsResolver;
 import org.jetbrains.bsp.bazel.server.sync.dependencytree.DependencyTree;
+import org.jetbrains.bsp.bazel.server.sync.languages.JVMLanguagePluginParser;
 import org.jetbrains.bsp.bazel.server.sync.languages.LanguagePlugin;
 import org.jetbrains.bsp.bazel.server.sync.languages.java.JavaLanguagePlugin;
 import org.jetbrains.bsp.bazel.server.sync.languages.java.JavaModule;
@@ -86,6 +88,11 @@ public class ScalaLanguagePlugin extends LanguagePlugin<ScalaModule> {
 
     buildTarget.setDataKind(BuildTargetDataKind.SCALA);
     buildTarget.setData(scalaBuildTarget);
+  }
+
+  @Override
+  public Option<Path> calculateSourceRoot(Path source) {
+    return JVMLanguagePluginParser.calculateJVMSourceRoot(source, true);
   }
 
   public Option<ScalacOptionsItem> toScalacOptionsItem(Module module) {

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/thrift/ThriftLanguagePlugin.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/thrift/ThriftLanguagePlugin.java
@@ -3,8 +3,11 @@ package org.jetbrains.bsp.bazel.server.sync.languages.thrift;
 import ch.epfl.scala.bsp4j.BuildTarget;
 import io.vavr.collection.HashSet;
 import io.vavr.collection.Set;
+import io.vavr.control.Option;
 import java.net.URI;
+import java.nio.file.Path;
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.TargetInfo;
+import org.jetbrains.bsp.bazel.server.bsp.utils.SourceRootGuesser;
 import org.jetbrains.bsp.bazel.server.sync.BazelPathsResolver;
 import org.jetbrains.bsp.bazel.server.sync.dependencytree.DependencyTree;
 import org.jetbrains.bsp.bazel.server.sync.languages.LanguagePlugin;
@@ -34,5 +37,10 @@ public class ThriftLanguagePlugin extends LanguagePlugin<ThriftModule> {
   @Override
   protected void applyModuleData(ThriftModule moduleData, BuildTarget buildTarget) {
     // no actions needed
+  }
+
+  @Override
+  public Option<Path> calculateSourceRoot(Path source) {
+    return Option.some(SourceRootGuesser.getSourcesRoot(source));
   }
 }

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/sync/languages/BUILD
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/sync/languages/BUILD
@@ -1,0 +1,13 @@
+load("//:junit5.bzl", "kt_junit5_test")
+
+kt_junit5_test(
+    name = "LanguagePluginServiceTest",
+    size = "small",
+    srcs = ["LanguagePluginServiceTest.kt"],
+    test_package = "org.jetbrains.bsp.bazel.server.sync.languages",
+    deps = [
+        "//bazelrunner",
+        "//server/src/main/java/org/jetbrains/bsp/bazel/server/sync",
+        "@maven//:io_vavr_vavr",
+    ],
+)

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/sync/languages/LanguagePluginServiceTest.kt
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/sync/languages/LanguagePluginServiceTest.kt
@@ -1,0 +1,396 @@
+package org.jetbrains.bsp.bazel.server.sync.languages
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.vavr.collection.HashSet
+import io.vavr.collection.Set
+import org.jetbrains.bsp.bazel.bazelrunner.BasicBazelInfo
+import org.jetbrains.bsp.bazel.server.sync.BazelPathsResolver
+import org.jetbrains.bsp.bazel.server.sync.languages.cpp.CppLanguagePlugin
+import org.jetbrains.bsp.bazel.server.sync.languages.java.JavaLanguagePlugin
+import org.jetbrains.bsp.bazel.server.sync.languages.java.JdkResolver
+import org.jetbrains.bsp.bazel.server.sync.languages.java.JdkVersionResolver
+import org.jetbrains.bsp.bazel.server.sync.languages.scala.ScalaLanguagePlugin
+import org.jetbrains.bsp.bazel.server.sync.languages.thrift.ThriftLanguagePlugin
+import org.jetbrains.bsp.bazel.server.sync.model.Language
+import org.junit.jupiter.api.*
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.createTempDirectory
+
+class LanguagePluginServiceTest {
+
+    private lateinit var languagePluginsService: LanguagePluginsService
+
+    @BeforeEach
+    fun beforeEach() {
+        val bazelInfo = BasicBazelInfo("", Paths.get(""))
+        val bazelPathsResolver = BazelPathsResolver(bazelInfo)
+        val jdkResolver = JdkResolver(bazelPathsResolver, JdkVersionResolver())
+        val javaLanguagePlugin = JavaLanguagePlugin(bazelPathsResolver, jdkResolver, bazelInfo)
+        val scalaLanguagePlugin = ScalaLanguagePlugin(javaLanguagePlugin, bazelPathsResolver)
+        val cppLanguagePlugin = CppLanguagePlugin()
+        val thriftLanguagePlugin = ThriftLanguagePlugin(bazelPathsResolver)
+        languagePluginsService = LanguagePluginsService(
+            scalaLanguagePlugin, javaLanguagePlugin, cppLanguagePlugin, thriftLanguagePlugin
+        )
+    }
+
+    @Nested
+    @DisplayName("Tests for the method shouldGetPlugin")
+    inner class ShouldGetPluginTest {
+
+        @Test
+        fun `should return JavaLanguagePlugin for Java Language`() {
+            // given
+            val languages: Set<Language> = HashSet.of(Language.JAVA)
+
+            // when
+            val plugin = languagePluginsService.getPlugin(languages) as? JavaLanguagePlugin
+
+            // then
+            plugin shouldNotBe null
+        }
+
+        @Test
+        fun `should return JavaLanguagePlugin for Kotlin Language`() {
+            // given
+            val languages: Set<Language> = HashSet.of(Language.KOTLIN)
+
+            // when
+            val plugin = languagePluginsService.getPlugin(languages) as? JavaLanguagePlugin
+
+            // then
+            plugin shouldNotBe null
+        }
+
+        @Test
+        fun `should return ScalaLanguagePlugin for Scala Language`() {
+            // given
+            val languages: Set<Language> = HashSet.of(Language.SCALA)
+
+            // when
+            val plugin = languagePluginsService.getPlugin(languages) as? ScalaLanguagePlugin
+
+            // then
+            plugin shouldNotBe null
+        }
+
+        @Test
+        fun `should return EmptyLanguagePlugin for no Language`() {
+            // given
+            val languages: Set<Language> = HashSet.of()
+
+            // when
+            val plugin = languagePluginsService.getPlugin(languages) as? EmptyLanguagePlugin
+
+            // then
+            plugin shouldNotBe null
+        }
+
+        @Test
+        fun `should return ThriftLanguagePlugin for Thrift Language`() {
+            // given
+            val languages: Set<Language> = HashSet.of(Language.THRIFT)
+
+            // when
+            val plugin = languagePluginsService.getPlugin(languages) as? ThriftLanguagePlugin
+
+            // then
+            plugin shouldNotBe null
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Tests for the method shouldGetSourceSet")
+    inner class ShouldGetSourceSetTest {
+        private lateinit var tmpRepo: Path
+
+        @BeforeEach
+        fun beforeEach() {
+            tmpRepo = createTempDirectory()
+        }
+
+        private fun createFileAndWrite(dirString: String, filename: String, content: String): Path? {
+            try {
+                val dirPath = tmpRepo.resolve(dirString)
+                Files.createDirectories(dirPath)
+                val filePath = dirPath.resolve(filename)
+                Files.createFile(filePath)
+                File(filePath.toUri()).writeText(content)
+                return filePath
+            } catch (e: IOException) {
+                e.printStackTrace()
+            }
+            return null
+        }
+
+        @AfterEach
+        fun afterEach() {
+            val tmpDir = tmpRepo.toFile()
+            tmpDir.deleteRecursively()
+        }
+
+        @Test
+        fun `should return sourceSet for Java Language`() {
+            // given
+            val dirString = "org/jetbrains/bsp/bazel/server/sync/languages/java/"
+            val filename = "JavaPackageTest.java"
+            val content = """
+                |package org.jetbrains.bsp.bazel.server.sync.languages.java;
+                |
+                |            public class JavaPackageTest{
+                |              public public static void main(String[] args) {
+                |                return;
+                |              }
+                |            }
+                """.trimMargin()
+            val filePath = createFileAndWrite(dirString, filename, content)
+            val plugin = languagePluginsService.getPlugin(HashSet.of(Language.JAVA))
+
+            // when
+            val result = plugin.calculateSourceRoot(filePath).get()
+
+            // then
+            result shouldBe tmpRepo
+        }
+
+        @Test
+        fun `should not return tmpRepo for empty file in Java Language`() {
+            // given
+            val dirString = "org/jetbrains/bsp/bazel/server/sync/languages/java/"
+            val filename = "JavaPackageTest.java"
+            val content = ""
+            val filePath = createFileAndWrite(dirString, filename, content)
+            val plugin = languagePluginsService.getPlugin(HashSet.of(Language.JAVA))
+
+            // when
+            val result = plugin.calculateSourceRoot(filePath).get()
+
+            // then
+            result shouldNotBe tmpRepo
+            result shouldBe tmpRepo.resolve(dirString)
+        }
+
+        @Test
+        fun `should not return tmpRepo for Java Language with wrong package declaration`() {
+            // given
+            val dirString = "org/jetbrains/bsp/bazel/server/sync/languages/java/"
+            val filename = "JavaPackageTest.java"
+            val content = """
+                |package org.jetbrains.bsp.bazel.server.sync.languages;
+                |package java;
+                |public class JavaPackageTest{
+                |  public public static void main(String[] args) {
+                |    return;
+                |  }
+                |}
+                """.trimMargin()
+            val filePath = createFileAndWrite(dirString, filename, content)
+            val plugin = languagePluginsService.getPlugin(HashSet.of(Language.JAVA))
+
+            // when
+            val result = plugin.calculateSourceRoot(filePath).get()
+
+            // then
+            result shouldNotBe tmpRepo
+            result shouldBe tmpRepo.resolve("org")
+        }
+
+        @Test
+        fun `should return sourceSet for Scala Language from one line package declaration`() {
+            // given
+            val dirString = "org/jetbrains/bsp/bazel/server/sync/languages/"
+            val filename = "ScalaPackageTest.java"
+            val content = """
+                |package org.jetbrains.bsp.bazel.server.sync.languages;
+                |            
+                |   class ScalaPackageTest{
+                |        def main(){
+                |                return null;
+                |              }
+                |            }
+                """.trimMargin()
+            val filePath = createFileAndWrite(dirString, filename, content)
+            val plugin = languagePluginsService.getPlugin(HashSet.of(Language.SCALA))
+
+            // when
+            val result = plugin.calculateSourceRoot(filePath).get()
+
+            // then
+            result shouldBe tmpRepo
+        }
+
+        @Test
+        fun `should return sourceSet for Scala Language from two line package declaration`() {
+            // given
+            val dirString = "org/jetbrains/bsp/bazel/server/sync/languages/scala/"
+            val filename = "ScalaPackageTest.java"
+            val content = """
+                |package org.jetbrains.bsp.bazel.server.sync.languages;
+                |package scala;
+                |
+                |class ScalaPackageTest{
+                |  def main(){
+                |    return null;
+                |  }
+                |}
+                """.trimMargin()
+            val filePath = createFileAndWrite(dirString, filename, content)
+            val plugin = languagePluginsService.getPlugin(HashSet.of(Language.SCALA))
+
+            // when
+            val result = plugin.calculateSourceRoot(filePath).get()
+
+            // then
+            result shouldBe tmpRepo
+        }
+
+        @Test
+        fun `should return sourceSet for Scala Language from multi line package declaration`() {
+            // given
+            val dirString = "org/jetbrains/bsp/bazel/server/sync/languages/scala/"
+            val filename = "ScalaPackageTest.java"
+            val content = """
+                |package org.jetbrains.bsp.bazel;
+                |package server.sync.languages;
+                |
+                |
+                |package scala;
+                |
+                |class ScalaPackageTest{
+                |  def main(){
+                |    return null;
+                |  }
+                |}
+                """.trimMargin()
+            val filePath = createFileAndWrite(dirString, filename, content)
+            val plugin = languagePluginsService.getPlugin(HashSet.of(Language.SCALA))
+
+            // when
+            val result = plugin.calculateSourceRoot(filePath).get()
+
+            // then
+            result shouldBe tmpRepo
+        }
+
+        @Test
+        fun `should not return tmpRepo for Scala Language from empty package declaration`() {
+            // given
+            val dirString = "org/jetbrains/bsp/bazel/server/sync/languages/"
+            val filename = "ScalaPackageTest.java"
+            val content = ""
+            val filePath = createFileAndWrite(dirString, filename, content)
+            val plugin = languagePluginsService.getPlugin(HashSet.of(Language.SCALA))
+
+            // when
+            val result = plugin.calculateSourceRoot(filePath).get()
+
+            // then
+            result shouldNotBe tmpRepo
+            result shouldBe tmpRepo.resolve(dirString)
+        }
+
+        @Test
+        fun `should return sourceSet for Kotlin Language`() {
+            // given
+            val dirString = "org/jetbrains/bsp/bazel/server/sync/languages/kotlin/"
+            val filename = "KotlinPackageTest.kt"
+            val content = """
+                |package org.jetbrains.bsp.bazel.server.sync.languages.kotlin
+                |            
+                |fun main() {
+                |    println("Hello, World!")
+                |}
+                """.trimMargin()
+            val filePath = createFileAndWrite(dirString, filename, content)
+            val plugin = languagePluginsService.getPlugin(HashSet.of(Language.KOTLIN))
+
+            // when
+            val result = plugin.calculateSourceRoot(filePath).get()
+
+            // then
+            result shouldBe tmpRepo
+        }
+
+        @Test
+        fun `should not return tmpRepo for Kotlin Language for empty file`() {
+            // given
+            val dirString = "org/jetbrains/bsp/bazel/server/sync/languages/kotlin/"
+            val filename = "KotlinPackageTest.kt"
+            val content = ""
+            val filePath = createFileAndWrite(dirString, filename, content)
+            val plugin = languagePluginsService.getPlugin(HashSet.of(Language.KOTLIN))
+
+            // when
+            val result = plugin.calculateSourceRoot(filePath).get()
+
+            // then
+            result shouldNotBe tmpRepo
+            result shouldBe tmpRepo.resolve(dirString)
+        }
+
+        @Test
+        fun `should return null for no Language`() {
+            // given
+            val dirString = "org/jetbrains/bsp/bazel/server/sync/languages/"
+            val filename = "EmptyPackageTest.java"
+            val content = """
+                |package org.jetbrains.bsp.bazel.server.sync.languages
+                |                       
+                """.trimMargin()
+
+            val filePath = createFileAndWrite(dirString, filename, content)
+            val plugin = languagePluginsService.getPlugin(HashSet.of())
+
+            // when
+            val result = plugin.calculateSourceRoot(filePath)
+
+            // then
+            result.isEmpty shouldBe true
+        }
+
+        @Test
+        fun `should not return tmpRepo for Thrift Language`() {
+            // given
+            val dirString = "org/jetbrains/bsp/bazel/server/sync/languages/"
+            val filename = "ThriftPackageTest.java"
+            val content = """
+                |package org.jetbrains.bsp.bazel.server.sync.languages
+                |            
+                |public class HelloWorldNative
+                |{
+                |        public static String hello(String name)
+                |        {
+                |                return "Hello, "+name;
+                |        }
+                |        
+                |        public static void main(String args[])
+                |        {
+                |                long start=System.currentTimeMillis();
+                |                for (int i=0;i<100000;i++)
+                |                {
+                |                        System.out.println(hello("world"+i));
+                |                }
+                |                long end=System.currentTimeMillis();
+                |                System.out.println((end-start)+" ms");
+                |        }
+                |}
+                """.trimMargin()
+            val filePath = createFileAndWrite(dirString, filename, content)
+            val plugin = languagePluginsService.getPlugin(HashSet.of(Language.THRIFT))
+
+            // when
+            val result = plugin.calculateSourceRoot(filePath).get()
+
+            // then
+            result shouldNotBe null
+            result shouldNotBe tmpRepo
+            result shouldBe tmpRepo.resolve(dirString)
+        }
+    }
+}


### PR DESCRIPTION
IntelliJ supports a package prefix attribute on source directories. The BSP spec and Scala plugin BSP client supports this data as well, but the implementation in bazel-bsp seems to not infer the prefix correctly. [BAZEL-54](https://youtrack.jetbrains.com/issue/BAZEL-54/package-prefix-in-bazel-bsp-not-inferred-correctly)
Added parsing of file looking for packages declaration for every compatible language.