### PR TITLE
[fix] excluded targets and directories cli flags bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 - e2e test for local jdk and remote jdk
   | [#253](https://github.com/JetBrains/bazel-bsp/pull/253)
   
+### Fixes 🛠️
+- CLI project view generator now supports `--excluded-targets` and `--excluded-directories` instead of excluded `-` prefix.
+  | [#267](https://github.com/JetBrains/bazel-bsp/pull/267)
+
 ## [2.1.0] - 11.05.2022
 
 ### Features 🎉

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/ProjectViewCLiOptionsProvider.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/ProjectViewCLiOptionsProvider.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.bsp.bazel.install
 
-
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import io.vavr.control.Try
 import org.jetbrains.bsp.bazel.install.cli.CliOptions
@@ -21,74 +20,77 @@ import kotlin.io.path.Path
 
 object ProjectViewCLiOptionsProvider {
 
-    private const val EXCLUDED_TARGET_PREFIX = "-"
-
     fun generateProjectViewAndSave(cliOptions: CliOptions, generatedProjectViewFilePath: Path): Try<ProjectView> {
         val projectView = toProjectView(cliOptions.projectViewCliOptions)
 
         return DefaultProjectViewGenerator.generatePrettyStringAndSaveInFile(projectView, generatedProjectViewFilePath)
-                .map { projectView }
+            .map { projectView }
     }
 
     private fun toProjectView(projectViewCliOptions: ProjectViewCliOptions?): ProjectView =
-            ProjectView(
-                    javaPath = toJavaPathSection(projectViewCliOptions),
-                    bazelPath = toBazelPathSection(projectViewCliOptions),
-                    debuggerAddress = toDebuggerAddressSection(projectViewCliOptions),
-                    targets = toTargetsSection(projectViewCliOptions),
-                    buildFlags = toBuildFlagsSection(projectViewCliOptions),
-                    directories = toDirectoriesSection(projectViewCliOptions),
-                    deriveTargetsFromDirectories = toDeriveTargetFlagSection(projectViewCliOptions),
-                    importDepth = toImportDepthSection(projectViewCliOptions),
-                    buildManualTargets = toBuildManualTargetsSection(projectViewCliOptions),
-            )
+        ProjectView(
+            javaPath = toJavaPathSection(projectViewCliOptions),
+            bazelPath = toBazelPathSection(projectViewCliOptions),
+            debuggerAddress = toDebuggerAddressSection(projectViewCliOptions),
+            targets = toTargetsSection(projectViewCliOptions),
+            buildFlags = toBuildFlagsSection(projectViewCliOptions),
+            directories = toDirectoriesSection(projectViewCliOptions),
+            deriveTargetsFromDirectories = toDeriveTargetFlagSection(projectViewCliOptions),
+            importDepth = toImportDepthSection(projectViewCliOptions),
+            buildManualTargets = toBuildManualTargetsSection(projectViewCliOptions),
+        )
 
     private fun toJavaPathSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewJavaPathSection? =
-            projectViewCliOptions?.javaPath?.let(::ProjectViewJavaPathSection)
+        projectViewCliOptions?.javaPath?.let(::ProjectViewJavaPathSection)
 
     private fun toBazelPathSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewBazelPathSection? =
-            projectViewCliOptions?.bazelPath?.let(::ProjectViewBazelPathSection)
+        projectViewCliOptions?.bazelPath?.let(::ProjectViewBazelPathSection)
 
     private fun toTargetsSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewTargetsSection? =
-            projectViewCliOptions?.targets?.let(::toTargetsSectionNotNull)
+        when {
+            projectViewCliOptions == null -> null
+            projectViewCliOptions.targets != null || projectViewCliOptions.excludedTargets != null ->
+                toTargetsSectionNotNull(projectViewCliOptions)
 
-    private fun toBuildManualTargetsSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewBuildManualTargetsSection? =
-            projectViewCliOptions?.buildManualTargets?.let(::ProjectViewBuildManualTargetsSection)
+            else -> null
+        }
 
-
-    private fun toTargetsSectionNotNull(targets: List<String>): ProjectViewTargetsSection {
-        val includedTargets = calculateIncludedValues(targets).map(::BuildTargetIdentifier)
-        val excludedTargets = calculateExcludedValues(targets).map(::BuildTargetIdentifier)
+    private fun toTargetsSectionNotNull(projectViewCliOptions: ProjectViewCliOptions): ProjectViewTargetsSection {
+        val includedTargets = projectViewCliOptions.targets.orEmpty().map { BuildTargetIdentifier(it) }
+        val excludedTargets = projectViewCliOptions.excludedTargets.orEmpty().map { BuildTargetIdentifier(it) }
 
         return ProjectViewTargetsSection(includedTargets, excludedTargets)
     }
 
-    private fun toDirectoriesSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewDirectoriesSection? =
-            projectViewCliOptions?.directories?.let(::toDirectoriesSectionNotNull)
+    private fun toBuildManualTargetsSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewBuildManualTargetsSection? =
+        projectViewCliOptions?.buildManualTargets?.let(::ProjectViewBuildManualTargetsSection)
 
-    private fun toDirectoriesSectionNotNull(directories: List<String>): ProjectViewDirectoriesSection {
-        val includedDirectories = calculateIncludedValues(directories).map(::Path)
-        val excludedDirectories = calculateExcludedValues(directories).map(::Path)
+
+    private fun toDirectoriesSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewDirectoriesSection? =
+        when {
+            projectViewCliOptions == null -> null
+            projectViewCliOptions.directories != null || projectViewCliOptions.excludedDirectories != null ->
+                toDirectoriesSectionNotNull(projectViewCliOptions)
+
+            else -> null
+        }
+
+    private fun toDirectoriesSectionNotNull(projectViewCliOptions: ProjectViewCliOptions): ProjectViewDirectoriesSection {
+        val includedDirectories = projectViewCliOptions.directories.orEmpty().map { Path(it) }
+        val excludedDirectories = projectViewCliOptions.excludedDirectories.orEmpty().map { Path(it) }
 
         return ProjectViewDirectoriesSection(includedDirectories, excludedDirectories)
     }
 
-    private fun toImportDepthSection(projectViewCliOptions: ProjectViewCliOptions?):  ProjectViewImportDepthSection? =
+    private fun toImportDepthSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewImportDepthSection? =
         projectViewCliOptions?.importDepth?.let(::ProjectViewImportDepthSection)
 
-    private fun calculateIncludedValues(targets: List<String>): List<String> =
-            targets.filterNot { it.startsWith(EXCLUDED_TARGET_PREFIX) }
-
-    private fun calculateExcludedValues(targets: List<String>): List<String> =
-            targets.filter { it.startsWith(EXCLUDED_TARGET_PREFIX) }
-                    .map { it.drop(1) }
-
     private fun toDebuggerAddressSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewDebuggerAddressSection? =
-            projectViewCliOptions?.debuggerAddress?.let(::ProjectViewDebuggerAddressSection)
+        projectViewCliOptions?.debuggerAddress?.let(::ProjectViewDebuggerAddressSection)
 
     private fun toBuildFlagsSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewBuildFlagsSection? =
-            projectViewCliOptions?.buildFlags?.let { ProjectViewBuildFlagsSection(it) }
+        projectViewCliOptions?.buildFlags?.let { ProjectViewBuildFlagsSection(it) }
 
     private fun toDeriveTargetFlagSection(projectViewCliOptions: ProjectViewCliOptions?): ProjectViewDeriveTargetsFromDirectoriesSection? =
-            projectViewCliOptions?.deriveTargetsFromDirectories?.let(::ProjectViewDeriveTargetsFromDirectoriesSection)
+        projectViewCliOptions?.deriveTargetsFromDirectories?.let(::ProjectViewDeriveTargetsFromDirectoriesSection)
 }

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptions.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptions.kt
@@ -12,9 +12,11 @@ data class ProjectViewCliOptions internal constructor(
         val bazelPath: Path?,
         val debuggerAddress: String?,
         val targets: List<String>?,
+        val excludedTargets: List<String>?,
         val buildFlags: List<String>?,
         val buildManualTargets: Boolean?,
         val directories: List<String>?,
+        val excludedDirectories: List<String>?,
         val deriveTargetsFromDirectories: Boolean?,
         val importDepth: Int?,
 )

--- a/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.kt
+++ b/install/src/main/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProvider.kt
@@ -53,6 +53,17 @@ class CliOptionsProvider(private val args: Array<String>) {
             .build()
         cliParserOptions.addOption(targetsOption)
 
+        val excludedTargetsOption = Option.builder()
+            .longOpt(EXCLUDED_TARGETS_LONG_OPT)
+            .hasArgs()
+            .argName("excluded targets")
+            .desc(
+                "Add excluded targets to the generated project view file, you can read more about it here:" +
+                        " https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#targets."
+            )
+            .build()
+        cliParserOptions.addOption(excludedTargetsOption)
+
         val buildFlagsOption = Option.builder(BUILD_FLAGS_SHORT_OPT)
             .longOpt("build_flags")
             .hasArgs()
@@ -101,7 +112,8 @@ class CliOptionsProvider(private val args: Array<String>) {
             .longOpt("build_manual_targets")
             .desc(
                 "Add build manual target to the generated project view file, you can read more about it here: " +
-                        "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#build_manual_targets.")
+                        "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#build_manual_targets."
+            )
             .build()
         cliParserOptions.addOption(manualTargetsOption)
 
@@ -111,17 +123,28 @@ class CliOptionsProvider(private val args: Array<String>) {
             .hasArgs()
             .argName("directories")
             .desc(
-                    "Add directories to the generated project view file, you can read more about it here: " +
-                            "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#directories."
+                "Add directories to the generated project view file, you can read more about it here: " +
+                        "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#directories."
             )
             .build()
         cliParserOptions.addOption(directoriesOption)
 
+        val excludedDirectoriesOption = Option.builder()
+            .longOpt(EXCLUDED_DIRECTORIES_LONG_OPT)
+            .hasArgs()
+            .argName("excluded directories")
+            .desc(
+                "Add excluded directories to the generated project view file, you can read more about it here: " +
+                        "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#directories."
+            )
+            .build()
+        cliParserOptions.addOption(excludedDirectoriesOption)
+
         val deriveTargetsFromDirectoriesOption = Option.builder(DERIVE_TARGETS_FLAG_SHORT_OPT)
             .longOpt("derive_targets_from_directories")
             .desc(
-                    "Add derive_targets_from_directories to the generated project view file, you can read more about it here: " +
-                            "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#derive_targets_from_directories."
+                "Add derive_targets_from_directories to the generated project view file, you can read more about it here: " +
+                        "https://github.com/JetBrains/bazel-bsp/tree/master/executioncontext/projectview#derive_targets_from_directories."
             )
             .build()
         cliParserOptions.addOption(deriveTargetsFromDirectoriesOption)
@@ -136,7 +159,7 @@ class CliOptionsProvider(private val args: Array<String>) {
             )
             .build()
         cliParserOptions.addOption(importDepthOption)
-        
+
         val useBloopOption = Option.builder(USE_BLOOP_SHORT_OPT)
             .longOpt("use_bloop")
             .desc("Use bloop as the BSP server rather than bazel-bsp.")
@@ -201,9 +224,11 @@ class CliOptionsProvider(private val args: Array<String>) {
                 bazelPath = bazelPath(cmd),
                 debuggerAddress = debuggerAddress(cmd),
                 targets = targets(cmd),
+                excludedTargets = excludedTargets(cmd),
                 buildFlags = buildFlags(cmd),
                 buildManualTargets = buildManualTargets(cmd),
                 directories = directories(cmd),
+                excludedDirectories = excludedDirectories(cmd),
                 deriveTargetsFromDirectories = deriveTargetsFlag(cmd),
                 importDepth = importDepth(cmd),
             )
@@ -211,6 +236,7 @@ class CliOptionsProvider(private val args: Array<String>) {
 
     private fun isAnyGenerationFlagSet(cmd: CommandLine): Boolean =
         cmd.hasOption(TARGETS_SHORT_OPT) or
+                cmd.hasOption(EXCLUDED_TARGETS_LONG_OPT) or
                 cmd.hasOption(JAVA_PATH_SHORT_OPT) or
                 cmd.hasOption(BAZEL_PATH_SHORT_OPT) or
                 cmd.hasOption(DEBUGGER_ADDRESS_SHORT_OPT) or
@@ -218,6 +244,7 @@ class CliOptionsProvider(private val args: Array<String>) {
                 cmd.hasOption(BUILD_MANUAL_TARGETS_OPT) or
                 cmd.hasOption(BUILD_FLAGS_SHORT_OPT) or
                 cmd.hasOption(DIRECTORIES_SHORT_OPT) or
+                cmd.hasOption(EXCLUDED_DIRECTORIES_LONG_OPT) or
                 cmd.hasOption(DERIVE_TARGETS_FLAG_SHORT_OPT) or
                 cmd.hasOption(IMPORT_DEPTH_SHORT_OPT)
 
@@ -238,11 +265,15 @@ class CliOptionsProvider(private val args: Array<String>) {
 
     private fun targets(cmd: CommandLine): List<String>? = cmd.getOptionValues(TARGETS_SHORT_OPT)?.toList()
 
+    private fun excludedTargets(cmd: CommandLine): List<String>? = cmd.getOptionValues(EXCLUDED_TARGETS_LONG_OPT)?.toList()
+
     private fun buildFlags(cmd: CommandLine): List<String>? = cmd.getOptionValues(BUILD_FLAGS_SHORT_OPT)?.toList()
 
     private fun calculateCurrentAbsoluteDirectory(): Path = Paths.get("").toAbsolutePath()
 
     private fun directories(cmd: CommandLine): List<String>? = cmd.getOptionValues(DIRECTORIES_SHORT_OPT)?.toList()
+
+    private fun excludedDirectories(cmd: CommandLine): List<String>? = cmd.getOptionValues(EXCLUDED_DIRECTORIES_LONG_OPT)?.toList()
 
     private fun deriveTargetsFlag(cmd: CommandLine): Boolean = cmd.hasOption(DERIVE_TARGETS_FLAG_SHORT_OPT)
 
@@ -251,12 +282,14 @@ class CliOptionsProvider(private val args: Array<String>) {
         private const val WORKSPACE_ROOT_DIR_SHORT_OPT = "d"
         private const val PROJECT_VIEW_FILE_PATH_SHORT_OPT = "p"
         private const val TARGETS_SHORT_OPT = "t"
+        private const val EXCLUDED_TARGETS_LONG_OPT = "excluded-targets"
         private const val BUILD_FLAGS_SHORT_OPT = "f"
         private const val BAZEL_PATH_SHORT_OPT = "b"
         private const val DEBUGGER_ADDRESS_SHORT_OPT = "x"
         private const val JAVA_PATH_SHORT_OPT = "j"
         private const val BUILD_MANUAL_TARGETS_OPT = "m"
         private const val DIRECTORIES_SHORT_OPT = "r"
+        private const val EXCLUDED_DIRECTORIES_LONG_OPT = "excluded-directories"
         private const val DERIVE_TARGETS_FLAG_SHORT_OPT = "v"
         private const val IMPORT_DEPTH_SHORT_OPT = "i"
         private const val USE_BLOOP_SHORT_OPT = "u"

--- a/install/src/test/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProviderTest.kt
+++ b/install/src/test/java/org/jetbrains/bsp/bazel/install/cli/CliOptionsProviderTest.kt
@@ -380,10 +380,8 @@ class CliOptionsProviderTest {
                 val args = arrayOf(
                         "-t",
                         "//included_target1",
-                        "-//excluded_target1",
                         "//included_target2",
                         "//included_target3",
-                        "-//excluded_target2",
                 )
 
                 // when
@@ -396,12 +394,39 @@ class CliOptionsProviderTest {
 
                 val expectedTargets = listOf(
                         "//included_target1",
-                        "-//excluded_target1",
                         "//included_target2",
                         "//included_target3",
-                        "-//excluded_target2",
                 )
                 cliOptions.projectViewCliOptions?.targets shouldBe expectedTargets
+            }
+        }
+
+        @Nested
+        @DisplayName("cliOptions.projectViewCliOptions.excludedTargets test")
+        inner class ExcludedTargetsTests {
+
+            @Test
+            fun `should return success if excluded targets are specified`() {
+                // given
+                val args = arrayOf(
+                    "--excluded-targets",
+                    "//excluded_target1",
+                    "//excluded_target2",
+                )
+
+                // when
+                val provider = CliOptionsProvider(args)
+                val cliOptionsTry = provider.getOptions()
+
+                // then
+                cliOptionsTry.isSuccess shouldBe true
+                val cliOptions = cliOptionsTry.get()
+
+                val expectedTargets = listOf(
+                    "//excluded_target1",
+                    "//excluded_target2",
+                )
+                cliOptions.projectViewCliOptions?.excludedTargets shouldBe expectedTargets
             }
         }
 
@@ -477,7 +502,6 @@ class CliOptionsProviderTest {
                         "-r",
                         "included_dir1",
                         "included_dir2",
-                        "-excluded_dir3"
                 )
 
                 // when
@@ -491,9 +515,38 @@ class CliOptionsProviderTest {
                 val expectedDirs = listOf(
                         "included_dir1",
                         "included_dir2",
-                        "-excluded_dir3",
                 )
                 cliOptions.projectViewCliOptions?.directories shouldBe expectedDirs
+            }
+        }
+
+        @Nested
+        @DisplayName("cliOptions.projectViewCliOptions.excludedDirectories test")
+        inner class ExcludedDirectoriesTest {
+            @Test
+            fun `should return success if excluded directories are specified`() {
+                // given
+                val args = arrayOf(
+                    "--excluded-directories",
+                    "excluded_dir1",
+                    "excluded_dir2",
+                    "excluded_dir3",
+                )
+
+                // when
+                val provider = CliOptionsProvider(args)
+                val cliOptionsTry = provider.getOptions()
+
+                // then
+                cliOptionsTry.isSuccess shouldBe true
+                val cliOptions = cliOptionsTry.get()
+
+                val expectedDirs = listOf(
+                    "excluded_dir1",
+                    "excluded_dir2",
+                    "excluded_dir3",
+                )
+                cliOptions.projectViewCliOptions?.excludedDirectories shouldBe expectedDirs
             }
         }
 
@@ -551,10 +604,11 @@ class CliOptionsProviderTest {
                     "host:8000",
                     "-t",
                     "//included_target1",
-                    "-//excluded_target1",
                     "//included_target2",
                     "//included_target3",
-                    "-//excluded_target2",
+                    "--excluded-targets",
+                    "//excluded_target1",
+                    "//excluded_target2",
                     "-f",
                     "--build_flag1=value1",
                     "--build_flag1=value2",
@@ -563,7 +617,8 @@ class CliOptionsProviderTest {
                     "-r",
                     "included_dir1",
                     "included_dir2",
-                    "-excluded_dir3",
+                    "--excluded-directories",
+                    "excluded_dir1",
                     "-v"
             )
 
@@ -593,13 +648,16 @@ class CliOptionsProviderTest {
 
             val expectedTargets = listOf(
                     "//included_target1",
-                    "-//excluded_target1",
                     "//included_target2",
                     "//included_target3",
-                    "-//excluded_target2",
             )
-
             cliOptions.projectViewCliOptions?.targets shouldBe expectedTargets
+
+            val expectedExcludedTargets = listOf(
+                    "//excluded_target1",
+                    "//excluded_target2",
+            )
+            cliOptions.projectViewCliOptions?.excludedTargets shouldBe expectedExcludedTargets
 
             val expectedBuildFlags = listOf("--build_flag1=value1", "--build_flag1=value2", "--build_flag1=value3")
             cliOptions.projectViewCliOptions?.buildFlags shouldBe expectedBuildFlags
@@ -609,9 +667,13 @@ class CliOptionsProviderTest {
             val expectedDirs = listOf(
                     "included_dir1",
                     "included_dir2",
-                    "-excluded_dir3",
             )
             cliOptions.projectViewCliOptions?.directories shouldBe expectedDirs
+
+            val expectedExcludedDirs = listOf(
+                    "excluded_dir1",
+            )
+            cliOptions.projectViewCliOptions?.excludedDirectories shouldBe expectedExcludedDirs
 
             cliOptions.projectViewCliOptions?.deriveTargetsFromDirectories shouldBe true
         }


### PR DESCRIPTION
Introducing `--excluded-targets` and `--excluded-directories` flags instead of `-` prefix in cli project view generator

one day in the future we'll replace this apache cli parser with some kotlin parser - but not today xd

---

https://youtrack.jetbrains.com/issue/BAZEL-103/cli-short-option-parsing-bug

---