### PR TITLE
[change] added cache of targets info in incremental syncs

### DIFF
--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/common/ServerContainer.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/common/ServerContainer.kt
@@ -11,13 +11,7 @@ import org.jetbrains.bsp.bazel.server.bsp.info.BspInfo
 import org.jetbrains.bsp.bazel.server.bsp.managers.BazelBspAspectsManager
 import org.jetbrains.bsp.bazel.server.bsp.managers.BazelBspCompilationManager
 import org.jetbrains.bsp.bazel.server.bsp.utils.InternalAspectsResolver
-import org.jetbrains.bsp.bazel.server.sync.BazelPathsResolver
-import org.jetbrains.bsp.bazel.server.sync.BazelProjectMapper
-import org.jetbrains.bsp.bazel.server.sync.FileProjectStorage
-import org.jetbrains.bsp.bazel.server.sync.ProjectProvider
-import org.jetbrains.bsp.bazel.server.sync.ProjectResolver
-import org.jetbrains.bsp.bazel.server.sync.ProjectStorage
-import org.jetbrains.bsp.bazel.server.sync.TargetKindResolver
+import org.jetbrains.bsp.bazel.server.sync.*
 import org.jetbrains.bsp.bazel.server.sync.languages.LanguagePluginsService
 import org.jetbrains.bsp.bazel.server.sync.languages.cpp.CppLanguagePlugin
 import org.jetbrains.bsp.bazel.server.sync.languages.java.JavaLanguagePlugin
@@ -72,11 +66,13 @@ class ServerContainer internal constructor(
             val targetKindResolver = TargetKindResolver()
             val bazelProjectMapper =
                 BazelProjectMapper(languagePluginsService, bazelPathsResolver, targetKindResolver)
+            val targetInfoReader = TargetInfoReader()
             val projectResolver = ProjectResolver(
                 bazelBspAspectsManager,
                 workspaceContextProvider,
                 bazelProjectMapper,
-                bspClientLogger
+                bspClientLogger,
+                targetInfoReader
             )
             val finalProjectStorage = projectStorage ?: FileProjectStorage(bspInfo, bspClientLogger)
             val projectProvider = ProjectProvider(projectResolver, finalProjectStorage)

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/ProjectResolver.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/ProjectResolver.kt
@@ -1,11 +1,5 @@
 package org.jetbrains.bsp.bazel.server.sync
 
-import com.google.protobuf.TextFormat
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.TargetInfo
 import org.jetbrains.bsp.bazel.logger.BspClientLogger
 import org.jetbrains.bsp.bazel.server.bep.BepOutput
@@ -14,16 +8,14 @@ import org.jetbrains.bsp.bazel.server.sync.model.Project
 import org.jetbrains.bsp.bazel.workspacecontext.WorkspaceContext
 import org.jetbrains.bsp.bazel.workspacecontext.WorkspaceContextProvider
 import java.net.URI
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.nio.file.Paths
 
 /** Responsible for querying bazel and constructing Project instance  */
 class ProjectResolver(
     private val bazelBspAspectsManager: BazelBspAspectsManager,
     private val workspaceContextProvider: WorkspaceContextProvider,
     private val bazelProjectMapper: BazelProjectMapper,
-    private val logger: BspClientLogger
+    private val logger: BspClientLogger,
+    private val targetInfoReader: TargetInfoReader
 ) {
     fun resolve(): Project {
         val workspaceContext = logger.timed(
@@ -39,7 +31,7 @@ class ProjectResolver(
         val rootTargets = bepOutput.rootTargets()
         val targets = logger.timed<Map<String, TargetInfo>>(
             "Parsing aspect outputs"
-        ) { readTargetMapFromAspectOutputs(aspectOutputs) }
+        ) { targetInfoReader.readTargetMapFromAspectOutputs(aspectOutputs) }
         return logger.timed<Project>(
             "Mapping to internal model"
         ) { bazelProjectMapper.createProject(targets, rootTargets, workspaceContext) }
@@ -52,17 +44,6 @@ class ProjectResolver(
             listOf(BSP_INFO_OUTPUT_GROUP, ARTIFACTS_OUTPUT_GROUP)
         )
 
-    private fun readTargetMapFromAspectOutputs(files: Set<URI>): Map<String, TargetInfo> =
-        runBlocking(Dispatchers.IO) {
-            files.asFlow().map(::readTargetInfoFromFile).toList().associateBy(TargetInfo::getId)
-        }
-
-    private fun readTargetInfoFromFile(uri: URI): TargetInfo {
-        val builder = TargetInfo.newBuilder()
-        val parser = TextFormat.Parser.newBuilder().setAllowUnknownFields(true).build()
-        parser.merge(Files.newBufferedReader(Paths.get(uri), StandardCharsets.UTF_8), builder)
-        return builder.build()
-    }
 
     companion object {
         private const val ASPECT_NAME = "bsp_target_info_aspect"

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/TargetInfoReader.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/TargetInfoReader.kt
@@ -1,0 +1,51 @@
+package org.jetbrains.bsp.bazel.server.sync
+
+import com.google.protobuf.TextFormat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.bsp.bazel.info.BspTargetInfo.TargetInfo
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.attribute.FileTime
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.io.path.getLastModifiedTime
+
+class TargetInfoReader {
+
+    data class CachedTargetInfo(val timestamp: FileTime, val bspTargetInfo: TargetInfo)
+
+    private val cache: ConcurrentHashMap<URI, CachedTargetInfo> = ConcurrentHashMap()
+
+    fun readTargetMapFromAspectOutputs(files: Set<URI>): Map<String, TargetInfo> =
+        runBlocking(Dispatchers.IO) {
+            files.asFlow().map(::getTargetInfo).toList()
+                .associateBy(TargetInfo::getId)
+        }
+
+    private fun readTargetInfoFromFile(uri: URI): TargetInfo {
+        val builder = TargetInfo.newBuilder()
+        val parser = TextFormat.Parser.newBuilder().setAllowUnknownFields(true).build()
+        parser.merge(Files.newBufferedReader(Paths.get(uri), StandardCharsets.UTF_8), builder)
+        return builder.build()
+    }
+
+    private fun getTargetInfo(uri: URI): TargetInfo {
+        val currentTimestamp = getFileTimeStamp(uri)
+        cache[uri]?.let { cached ->
+            if (cached.timestamp == currentTimestamp)
+                return cached.bspTargetInfo
+        }
+        val targetInfo = readTargetInfoFromFile(uri)
+        cache[uri] = CachedTargetInfo(currentTimestamp, targetInfo)
+        return targetInfo
+    }
+
+    private fun getFileTimeStamp(uri: URI): FileTime {
+        return Paths.get(uri).getLastModifiedTime()
+    }
+}


### PR DESCRIPTION
I moved reading target info from ProjectResolver class to new ProjectFileParser class and added HashMap caching info about Target with LastModified timestamps for every file to optimise parsing file that hadn't had any changes between incremental Syncs. Thank to that I was able to reduce the time of next sync (for example from ca. 20s in first import to ca. 300ms to next import without changes in files)