### PR TITLE
[maintenance] fix coursier command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ For example, using Coursier:
 ```shell
 cd ~/src/my-repository
 cs launch org.jetbrains.bsp:bazel-bsp:2.2.0 -M org.jetbrains.bsp.bazel.install.Install \
+  -- \
   --use_bloop \
   -t //my-targets/... \
   -d ~/bazel-bsp-projects/my-targets-project 


### PR DESCRIPTION
coursier needs a `--` after the class to launch and arguments