### PR TITLE
[fix] don't use Label.toString now that it's no longer overriden

### DIFF
--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bloop/BspModuleExporter.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bloop/BspModuleExporter.kt
@@ -95,7 +95,7 @@ class BspModuleExporter(
         val classesDir = out.resolve("classes")
         val resources = module.resources
         return Project(
-            module.label.toString(),
+            module.label.value,
             Paths.get(module.baseDirectory),
             Option.apply(Paths.get(project.workspaceRoot)),
             ScalaInterop.emptyList(),

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bloop/Naming.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bloop/Naming.java
@@ -11,7 +11,7 @@ class Naming {
   public static String compilerOutputNameFor(Label label) {
     try {
       var digest = MessageDigest.getInstance("MD5");
-      digest.update(label.toString().getBytes(StandardCharsets.UTF_8));
+      digest.update(label.getValue().getBytes(StandardCharsets.UTF_8));
       return "z_" + BaseEncoding.base16().encode(digest.digest()).substring(0, 12);
     } catch (Exception e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
https://github.com/JetBrains/bazel-bsp/commit/57c2c19c33e3055adeba9d043d9269435ddb83ac removed the override of Label.toString, which broke its representation in a couple places, this changes them to use `.value` instead.