### PR TITLE
[fix] workspace root is always used as a bazel directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@
 ### Changes 🔄
 
 ### Fixes 🛠️
+
 - Workspace root is always used as a bazel directory.
   | [#284](https://github.com/JetBrains/bazel-bsp/pull/284)
-
 - Kebab case in the installer flags & help typo fix & log typo fix.
   | [#283](https://github.com/JetBrains/bazel-bsp/pull/283)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Changes 🔄
 
 ### Fixes 🛠️
+- Workspace root is always used as a bazel directory.
+  | [#284](https://github.com/JetBrains/bazel-bsp/pull/284)
 
 - Kebab case in the installer flags & help typo fix & log typo fix.
   | [#283](https://github.com/JetBrains/bazel-bsp/pull/283)

--- a/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/BazelRunner.kt
+++ b/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/BazelRunner.kt
@@ -15,6 +15,7 @@ class BazelRunner private constructor(
   companion object {
     private val LOGGER = LogManager.getLogger(BazelRunner::class.java)
 
+    // TODO: can we remove this logic?
     // This is runner without workspace path. It is used to determine workspace
     // path and create a fully functional runner.
     @JvmStatic

--- a/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/BazelRunner.kt
+++ b/bazelrunner/src/main/java/org/jetbrains/bsp/bazel/bazelrunner/BazelRunner.kt
@@ -15,14 +15,6 @@ class BazelRunner private constructor(
   companion object {
     private val LOGGER = LogManager.getLogger(BazelRunner::class.java)
 
-    // TODO: can we remove this logic?
-    // This is runner without workspace path. It is used to determine workspace
-    // path and create a fully functional runner.
-    @JvmStatic
-    fun inCwd(workspaceContextProvider: WorkspaceContextProvider, bspClientLogger: BspClientLogger): BazelRunner {
-      return BazelRunner(workspaceContextProvider, bspClientLogger, workspaceRoot = null)
-    }
-
     @JvmStatic
     fun of(
         workspaceContextProvider: WorkspaceContextProvider,

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/BazelBspServer.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/BazelBspServer.kt
@@ -22,7 +22,7 @@ import org.jetbrains.bsp.bazel.workspacecontext.WorkspaceContextProvider
 import java.nio.file.Path
 
 class BazelBspServer(
-    bspInfo: BspInfo, workspaceContextProvider: WorkspaceContextProvider, workspaceRoot: Path?
+    bspInfo: BspInfo, workspaceContextProvider: WorkspaceContextProvider, workspaceRoot: Path
 ) {
     private val bazelRunner: BazelRunner
     private val bazelInfo: BazelInfo

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/ServerInitializer.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/ServerInitializer.kt
@@ -10,9 +10,10 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
 import java.util.concurrent.Executors
+import kotlin.io.path.Path
 import kotlin.system.exitProcess
 
-data class CliArgs(val bazelWorkspaceRoot: String?, val projectViewPath: String?)
+data class CliArgs(val bazelWorkspaceRoot: String, val projectViewPath: String?)
 
 object ServerInitializer {
     @JvmStatic
@@ -24,7 +25,7 @@ object ServerInitializer {
             )
             exitProcess(1)
         } else {
-            CliArgs(args.elementAtOrNull(0), args.elementAtOrNull(1))
+            CliArgs(args.elementAt(0), args.elementAtOrNull(1))
         }
         var hasErrors = false
         val stdout = System.out
@@ -42,10 +43,7 @@ object ServerInitializer {
             )
             val workspaceContextProvider = getWorkspaceContextProvider(cliArgs.projectViewPath)
             val bspIntegrationData = BspIntegrationData(stdout, stdin, executor, traceWriter)
-            val bspServer = BazelBspServer(
-                bspInfo, workspaceContextProvider,
-                cliArgs.bazelWorkspaceRoot?.let { Paths.get(it) }
-            )
+            val bspServer = BazelBspServer(bspInfo, workspaceContextProvider, Path(cliArgs.bazelWorkspaceRoot))
             bspServer.startServer(bspIntegrationData)
             val server = bspIntegrationData.server.start()
             bspServer.setBesBackendPort(server.port)

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/common/ServerContainer.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/common/ServerContainer.kt
@@ -21,7 +21,6 @@ import org.jetbrains.bsp.bazel.server.sync.languages.scala.ScalaLanguagePlugin
 import org.jetbrains.bsp.bazel.server.sync.languages.thrift.ThriftLanguagePlugin
 import org.jetbrains.bsp.bazel.workspacecontext.WorkspaceContextProvider
 import java.nio.file.Path
-import java.nio.file.Paths
 
 class ServerContainer internal constructor(
     val projectProvider: ProjectProvider,
@@ -41,9 +40,9 @@ class ServerContainer internal constructor(
         ): ServerContainer {
             val bspClientLogger = BspClientLogger()
             val bazelInfoStorage = BazelInfoStorage(bspInfo)
-            val bazelDataResolver = workspaceRoot?.let { root: Path ->
+            val bazelDataResolver = workspaceRoot?.let {
                 BazelInfoResolver(
-                    of(workspaceContextProvider, bspClientLogger, workspaceRoot), bazelInfoStorage
+                    of(workspaceContextProvider, bspClientLogger, it), bazelInfoStorage
                 )
             } ?: BazelInfoResolver(
                 inCwd(workspaceContextProvider, bspClientLogger), bazelInfoStorage
@@ -51,7 +50,7 @@ class ServerContainer internal constructor(
             val bazelInfo = bazelDataResolver.resolveBazelInfo()
 
             val bazelRunner = of(
-                workspaceContextProvider, bspClientLogger, workspaceRoot
+                workspaceContextProvider, bspClientLogger, bazelInfo.workspaceRoot
             )
             val compilationManager = BazelBspCompilationManager(bazelRunner)
             val aspectsResolver = InternalAspectsResolver(bspInfo)

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/common/ServerContainer.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/common/ServerContainer.kt
@@ -4,8 +4,6 @@ import org.jetbrains.bsp.bazel.bazelrunner.BazelInfo
 import org.jetbrains.bsp.bazel.bazelrunner.BazelInfoResolver
 import org.jetbrains.bsp.bazel.bazelrunner.BazelInfoStorage
 import org.jetbrains.bsp.bazel.bazelrunner.BazelRunner
-import org.jetbrains.bsp.bazel.bazelrunner.BazelRunner.Companion.inCwd
-import org.jetbrains.bsp.bazel.bazelrunner.BazelRunner.Companion.of
 import org.jetbrains.bsp.bazel.logger.BspClientLogger
 import org.jetbrains.bsp.bazel.server.bsp.info.BspInfo
 import org.jetbrains.bsp.bazel.server.bsp.managers.BazelBspAspectsManager
@@ -35,21 +33,19 @@ class ServerContainer internal constructor(
         fun create(
             bspInfo: BspInfo,
             workspaceContextProvider: WorkspaceContextProvider,
-            workspaceRoot: Path?,
+            workspaceRoot: Path,
             projectStorage: ProjectStorage?
         ): ServerContainer {
             val bspClientLogger = BspClientLogger()
             val bazelInfoStorage = BazelInfoStorage(bspInfo)
-            val bazelDataResolver = workspaceRoot?.let {
+            val bazelDataResolver =
                 BazelInfoResolver(
-                    of(workspaceContextProvider, bspClientLogger, it), bazelInfoStorage
+                    BazelRunner.of(workspaceContextProvider, bspClientLogger, workspaceRoot),
+                    bazelInfoStorage
                 )
-            } ?: BazelInfoResolver(
-                inCwd(workspaceContextProvider, bspClientLogger), bazelInfoStorage
-            )
             val bazelInfo = bazelDataResolver.resolveBazelInfo()
 
-            val bazelRunner = of(
+            val bazelRunner = BazelRunner.of(
                 workspaceContextProvider, bspClientLogger, bazelInfo.workspaceRoot
             )
             val compilationManager = BazelBspCompilationManager(bazelRunner)


### PR DESCRIPTION
so now we are using workspace root always - even if user specifies a directory inside the workspace