### PR TITLE
[fix] fix transitive target failure check in bloop export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ## [Unreleased]
 
+### Fixes 🛠️
+
+- Fix transitive target failure check in bloop export
+  | [#287](https://github.com/JetBrains/bazel-bsp/pull/287)
+
 ## [2.2.1] - 09.08.2022
 
 ### Fixes 🛠️

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/bloop/BUILD
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/bloop/BUILD
@@ -1,6 +1,16 @@
 load("//:junit5.bzl", "kt_junit5_test")
 
 kt_junit5_test(
+    name = "BloopExporterTests",
+    size = "small",
+    srcs = ["BloopExporterTest.kt"],
+    test_package = "org.jetbrains.bsp.bazel.server.bloop",
+    deps = [
+        "//server/src/main/java/org/jetbrains/bsp/bazel/server/bloop",
+    ],
+)
+
+kt_junit5_test(
     name = "BspModuleExporterTest",
     size = "small",
     srcs = ["BspModuleExporterTest.kt"],

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/bloop/BloopExporterTest.kt
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/bloop/BloopExporterTest.kt
@@ -1,0 +1,33 @@
+package org.jetbrains.bsp.bazel.server.bloop
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import org.jetbrains.bsp.bazel.server.bloop.BloopExporter.BazelExportFailedException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+
+class BloopExporterTest {
+    @Test
+    fun export_project_with_failed_direct_target_succeeds() {
+        val projectTargets = setOf(BuildTargetIdentifier("a"), BuildTargetIdentifier("b"))
+        val failedTargets = setOf(BuildTargetIdentifier("a"))
+
+        try {
+            BloopExporter.validateNoFailedExternalTargets(projectTargets, failedTargets)
+        } catch (ex: BazelExportFailedException) {
+            fail(ex)
+        }
+    }
+
+    @Test
+    fun export_project_with_failed_transitive_target_fails() {
+        val projectTargets = setOf(BuildTargetIdentifier("a"), BuildTargetIdentifier("b"))
+        val failedTargets = setOf(BuildTargetIdentifier("c"))
+
+        try {
+            BloopExporter.validateNoFailedExternalTargets(projectTargets, failedTargets)
+        } catch (ex: BazelExportFailedException) {
+            return
+        }
+        fail("a BazelExportFailedException was expected but none was thrown")
+    }
+}


### PR DESCRIPTION
#261 accidentally switched the predicate to test if any transitive targets failed, resulting in direct failures causing project imports to fail, and transitive ones to succeed.  This is the opposite of what should happen.

This changes it back, and adds a unit test.