### PR TITLE
[change] improve reglobbing logic for bloop reglobbing

### DIFF
--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bloop/ReGlobber.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bloop/ReGlobber.kt
@@ -27,10 +27,10 @@ object ReGlobber {
             return basePath
         }
 
-        val maxPrefixLen = paths.minOf { it.nameCount }
+        val maxPrefixLen = paths.minOf { it.nameCount } - 1
         val prefix = mutableListOf<String>()
 
-        for (n in 0..maxPrefixLen) {
+        for (n in 0 until maxPrefixLen) {
             val prefixPart = paths[0].getName(n)
             if (paths.all { it.getName(n) == prefixPart }) {
                 prefix.add(prefixPart.toString())

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bloop/ReGlobber.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bloop/ReGlobber.kt
@@ -7,11 +7,11 @@ import org.jetbrains.bsp.bazel.server.bloop.ScalaInterop.toOption
 import org.jetbrains.bsp.bazel.server.bloop.ScalaInterop.toScalaList
 import org.jetbrains.bsp.bazel.server.sync.model.SourceSet
 import scala.Option
-import scala.collection.immutable.List
 import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.math.max
+import scala.collection.immutable.List as SList
 
 object ReGlobber {
     fun reGlob(baseDirectory: URI, sourceSet: SourceSet): ReGlobbed {
@@ -22,19 +22,53 @@ object ReGlobber {
         return ReGlobbed(sourceGlobs, sources)
     }
 
-    private fun reGlobImpl(baseDirectory: URI, sources: Set<URI>): List<SourcesGlobs>? {
-        val basePath = Paths.get(baseDirectory)
-        val sourcePaths = sources.map(Paths::get)
-        var relativeLevels = 0
-        val extensions = sourcePaths
+    private fun commonPrefix(basePath: Path, paths: List<Path>): Path {
+        if (paths.isEmpty()) {
+            return basePath
+        }
+
+        val maxPrefixLen = paths.minOf { it.nameCount }
+        val prefix = mutableListOf<String>()
+
+        for (n in 0..maxPrefixLen) {
+            val prefixPart = paths[0].getName(n)
+            if (paths.all { it.getName(n) == prefixPart }) {
+                prefix.add(prefixPart.toString())
+            } else {
+                break
+            }
+        }
+
+        return if (prefix.isEmpty()) basePath
+        else basePath.resolve(Paths.get(prefix.first(), *prefix.drop(1).toTypedArray()))
+    }
+
+    private fun makeRelative(basePath: Path, paths: List<Path>): List<Path> =
+        paths
             .asSequence()
             .map(basePath::relativize)
             .filter { !it.startsWith("..") }
+            .toList()
+
+    private fun reGlobImpl(baseDirectory: URI, sources: Set<URI>): SList<SourcesGlobs>? {
+        var basePath = Paths.get(baseDirectory)
+        val sourcePaths = sources.map(Paths::get)
+        var relativeLevels = 0
+
+        var relativePaths = makeRelative(basePath, sourcePaths)
+        val newPrefix = commonPrefix(basePath, relativePaths)
+        if (newPrefix != basePath) {
+            basePath = newPrefix
+            relativePaths = makeRelative(newPrefix, sourcePaths)
+        }
+
+        val extensions = relativePaths
             .mapNotNull {
                 relativeLevels = max(relativeLevels, it.nameCount)
                 Files.getFileExtension(it.toString()).takeUnless(String::isEmpty)
             }.distinct()
             .toList()
+
         return if (relativeLevels == 0) {
             null
         } else {
@@ -54,7 +88,7 @@ object ReGlobber {
     }
 
     class ReGlobbed(
-        val globs: Option<List<SourcesGlobs>>,
-        val sources: List<Path>
+        val globs: Option<SList<SourcesGlobs>>,
+        val sources: SList<Path>
     )
 }

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/bloop/ReGlobberTest.kt
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/bloop/ReGlobberTest.kt
@@ -56,4 +56,50 @@ class ReGlobberTest {
             )
         )
     }
+
+    @Test
+    fun `reglobs sources with one level and base path`() {
+        val basePath = Paths.get("base/path/")
+        val sourceSet = SourceSet(
+            hashSetOf(
+                basePath.resolve(Paths.get("src/main/child/file1.scala")).toUri(),
+                basePath.resolve(Paths.get("src/main/child/file2.scala")).toUri()
+            ),
+            emptySet()
+        )
+        val reglobbed = ReGlobber.reGlob(basePath.toUri(), sourceSet)
+
+        CollectionConverters.asJava(reglobbed.sources).shouldBeEmpty()
+        reglobbed.globs.get() shouldBe scalaListOf(
+            Config.SourcesGlobs(
+                basePath.resolve("src/main/child").toAbsolutePath(),
+                scala.Option.apply(1),
+                scalaListOf("glob:*.scala"),
+                emptyList()
+            )
+        )
+    }
+
+    @Test
+    fun `reglobs sources with two levels and base path`() {
+        val basePath = Paths.get("base/path/")
+        val sourceSet = SourceSet(
+            hashSetOf(
+                basePath.resolve(Paths.get("src/main/child/dir1/file1.scala")).toUri(),
+                basePath.resolve(Paths.get("src/main/child/file2.scala")).toUri()
+            ),
+            emptySet()
+        )
+        val reglobbed = ReGlobber.reGlob(basePath.toUri(), sourceSet)
+
+        CollectionConverters.asJava(reglobbed.sources).shouldBeEmpty()
+        reglobbed.globs.get() shouldBe scalaListOf(
+            Config.SourcesGlobs(
+                basePath.resolve("src/main/child").toAbsolutePath(),
+                scala.Option.empty(),
+                scalaListOf("glob:**.scala"),
+                emptyList()
+            )
+        )
+    }
 }


### PR DESCRIPTION
This improves the logic in the reglobber to be smarter if multiple targets share the same base path, for example, if multiple targets are in the same BUILD file in `root`, and have targets that look like:

```
scala_library(
  name = 'a',
  srcs = [globs("a/src/main/**.scala")]
)

scala_library(
  name = 'b',
  srcs = [globs("b/src/main/**.scala")]
)
```

Previously the logic would end up with both `a` and `b` having a glob of `**.scala`, the new logic in this review changes it so a would be a glob with root directory of `root/a/src/main` and b of `root/b/src/main`.