### PR TITLE
[fix] `JVMLanguagePluginParser.calculateJVMSourceRoot` does not throw an exception for package longer than the path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,18 @@
 
 ### Changes 🔄
 
-- Pass originId into server responses.
-  | [#289](https://github.com/JetBrains/bazel-bsp/pull/289)
+- Add async and sync output processors.
+  | [#288](https://github.com/JetBrains/bazel-bsp/pull/288)
 - Pass originId into diagnostics.
   | [#291](https://github.com/JetBrains/bazel-bsp/pull/291)
+- Pass originId into server responses.
+  | [#289](https://github.com/JetBrains/bazel-bsp/pull/289)
 
 ### Fixes 🛠️
 
+- `JVMLanguagePluginParser.calculateJVMSourceRoot` does not throw 
+  an exception for package longer than the path.
+  | [#294](https://github.com/JetBrains/bazel-bsp/pull/294)
 - Fix transitive target failure check in bloop export.
   | [#287](https://github.com/JetBrains/bazel-bsp/pull/287)
 

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/JVMLanguagePluginParser.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/JVMLanguagePluginParser.kt
@@ -13,9 +13,10 @@ object JVMLanguagePluginParser {
         val sourcePackage =
             findPackage(source, multipleLines) ?: return SourceRootGuesser.getSourcesRoot(source)
         val sourcePackagePath = Paths.get(sourcePackage.replace(".", "/"))
-        return Paths.get("/").resolve(
-            source.subpath(0, source.nameCount - sourcePackagePath.nameCount - 1)
-        )
+        val sourceRootEndIndex = source.nameCount - sourcePackagePath.nameCount - 1
+
+        return if (sourceRootEndIndex < 0) source.parent
+        else Paths.get("/").resolve(source.subpath(0, sourceRootEndIndex))
     }
 
     private fun findPackage(source: Path, multipleLines: Boolean): String? {

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/sync/languages/BUILD
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/sync/languages/BUILD
@@ -1,6 +1,16 @@
 load("//:junit5.bzl", "kt_junit5_test")
 
 kt_junit5_test(
+    name = "JVMLanguagePluginParserTest",
+    size = "small",
+    srcs = ["JVMLanguagePluginParserTest.kt"],
+    test_package = "org.jetbrains.bsp.bazel.server.sync.languages",
+    deps = [
+        "//server/src/main/java/org/jetbrains/bsp/bazel/server/sync",
+    ],
+)
+
+kt_junit5_test(
     name = "LanguagePluginServiceTest",
     size = "small",
     srcs = ["LanguagePluginServiceTest.kt"],

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/sync/languages/JVMLanguagePluginParserTest.kt
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/sync/languages/JVMLanguagePluginParserTest.kt
@@ -1,0 +1,83 @@
+package org.jetbrains.bsp.bazel.server.sync.languages
+
+import io.kotest.matchers.shouldBe
+import org.jetbrains.bsp.bazel.utils.dope.DopeTemp
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import kotlin.io.path.writeText
+
+class JVMLanguagePluginParserTest {
+
+    @Test
+    fun `should return source dir for empty package`() {
+        // given
+        val fileContent = """
+            |
+            |public class Test {
+            |}
+            |
+        """.trimMargin()
+
+        val sourceRoot = DopeTemp.createTempPath("path/to/source/")
+        val sourceDir = Files.createDirectories(sourceRoot.resolve("dir1/dir2/dir3/"))
+
+        val sourceFile = Files.createFile(sourceDir.resolve("File.java"))
+        sourceFile.writeText(fileContent)
+
+        // when
+        val calculatedSourceRoot = JVMLanguagePluginParser.calculateJVMSourceRoot(sourceFile)
+
+        // then
+        calculatedSourceRoot shouldBe sourceDir
+    }
+
+    @Test
+    fun `should return source root as a sub path for package corresponding to path`() {
+        // given
+        val packageName = "dir1.dir2.dir3"
+        val fileContent = """
+            |package $packageName
+            |
+            |public class Test {
+            |}
+            |
+        """.trimMargin()
+
+        val sourceRoot = DopeTemp.createTempPath("path/to/source/")
+        val sourceDir = Files.createDirectories(sourceRoot.resolve("dir1/dir2/dir3/"))
+
+        val sourceFile = Files.createFile(sourceDir.resolve("File.java"))
+        sourceFile.writeText(fileContent)
+
+        // when
+        val calculatedSourceRoot = JVMLanguagePluginParser.calculateJVMSourceRoot(sourceFile)
+
+        // then
+        calculatedSourceRoot shouldBe sourceRoot
+    }
+
+    @Test
+    fun `should return source dir for package longer than the path`() {
+        // given
+        val packageName = (1..100).joinToString(".") { "dir$it" }
+        val fileContent = """
+            |package $packageName
+            |
+            |public class Test {
+            |}
+            |
+        """.trimMargin()
+
+        val sourceRoot = DopeTemp.createTempPath("path/to/source/")
+        val sourceDir = Files.createDirectories(sourceRoot.resolve("dir1/dir2/dir3/"))
+
+        val sourceFile = Files.createFile(sourceDir.resolve("File.java"))
+        sourceFile.writeText(fileContent)
+
+        // when
+        val calculatedSourceRoot = JVMLanguagePluginParser.calculateJVMSourceRoot(sourceFile)
+
+        // then
+        calculatedSourceRoot shouldBe sourceDir
+    }
+}


### PR DESCRIPTION
fixes https://youtrack.jetbrains.com/issue/BAZEL-154