### PR TITLE
[fix] `BuildTargetIdentifier` mapping uses `.uri` instead of `.toString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixes 🛠️
 
+- `BuildTargetIdentifier` mapping uses `.uri` instead of `.toString`.
+  | [#295](https://github.com/JetBrains/bazel-bsp/pull/295)
 - `JVMLanguagePluginParser.calculateJVMSourceRoot` does not throw 
   an exception for package longer than the path.
   | [#294](https://github.com/JetBrains/bazel-bsp/pull/294)

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/BspMappings.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/BspMappings.kt
@@ -26,7 +26,7 @@ object BspMappings {
 
     fun toBspUri(uri: URI): String = uri.toString()
 
-    fun toBspUri(uri: BuildTargetIdentifier): String = uri.toString()
+    fun toBspUri(uri: BuildTargetIdentifier): String = uri.uri
 
     fun getModules(project: Project, targets: List<BuildTargetIdentifier>): Set<Module> =
         toLabels(targets).mapNotNull(project::findModule).toSet()


### PR DESCRIPTION
we had a lil bug xd