### PR TITLE
[fix] use source deps from JavaInfo if they are available for thrift targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   | [#294](https://github.com/JetBrains/bazel-bsp/pull/294)
 - Fix transitive target failure check in bloop export.
   | [#287](https://github.com/JetBrains/bazel-bsp/pull/287)
+- Use direct source dependencies for thrift targets if present.
+  | [#298](https://github.com/JetBrains/bazel-bsp/pull/298)
 
 ## [2.2.1] - 09.08.2022
 


### PR DESCRIPTION
Certain thrift generators (scrooge) now put the library source directly on the thrift_library target.  This changes the language plugin to also look at the JavaInfo on the target (if its populated) and get the sources from there as well.