### PR TITLE
[fix] postpone bazel info

### DIFF
--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/ServerInitializer.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/ServerInitializer.kt
@@ -50,7 +50,7 @@ object ServerInitializer {
             bspIntegrationData.launcher.startListening()
             server.awaitTermination()
         } catch (e: Exception) {
-            e.printStackTrace()
+            e.printStackTrace(System.err)
             hasErrors = true
         } finally {
             executor.shutdown()

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/BazelServices.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/BazelServices.java
@@ -1,0 +1,38 @@
+package org.jetbrains.bsp.bazel.server.bsp;
+
+import org.jetbrains.bsp.bazel.server.sync.ExecuteService;
+import org.jetbrains.bsp.bazel.server.sync.ProjectSyncService;
+
+public class BazelServices {
+  private final BazelBspServerLifetime serverLifetime;
+  private final BspRequestsRunner bspRequestsRunner;
+  private final ProjectSyncService projectSyncService;
+  private final ExecuteService executeService;
+
+  public BazelServices(
+      BazelBspServerLifetime serverLifetime,
+      BspRequestsRunner bspRequestsRunner,
+      ProjectSyncService projectSyncService,
+      ExecuteService executeService) {
+    this.serverLifetime = serverLifetime;
+    this.bspRequestsRunner = bspRequestsRunner;
+    this.projectSyncService = projectSyncService;
+    this.executeService = executeService;
+  }
+
+  public BazelBspServerLifetime getServerLifetime() {
+    return serverLifetime;
+  }
+
+  public BspRequestsRunner getBspRequestsRunner() {
+    return bspRequestsRunner;
+  }
+
+  public ProjectSyncService getProjectSyncService() {
+    return projectSyncService;
+  }
+
+  public ExecuteService getExecuteService() {
+    return executeService;
+  }
+}

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/common/ServerContainer.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/common/ServerContainer.kt
@@ -18,7 +18,6 @@ import org.jetbrains.bsp.bazel.server.sync.languages.java.JdkVersionResolver
 import org.jetbrains.bsp.bazel.server.sync.languages.scala.ScalaLanguagePlugin
 import org.jetbrains.bsp.bazel.server.sync.languages.thrift.ThriftLanguagePlugin
 import org.jetbrains.bsp.bazel.workspacecontext.WorkspaceContextProvider
-import java.nio.file.Path
 
 class ServerContainer internal constructor(
     val projectProvider: ProjectProvider,
@@ -31,24 +30,21 @@ class ServerContainer internal constructor(
     companion object {
         @JvmStatic
         fun create(
-            bspInfo: BspInfo,
-            workspaceContextProvider: WorkspaceContextProvider,
-            workspaceRoot: Path,
-            projectStorage: ProjectStorage?
+                bspInfo: BspInfo,
+                workspaceContextProvider: WorkspaceContextProvider,
+                projectStorage: ProjectStorage?,
+                bspClientLogger: BspClientLogger,
+                bazelRunner: BazelRunner,
+                compilationManager: BazelBspCompilationManager
         ): ServerContainer {
-            val bspClientLogger = BspClientLogger()
             val bazelInfoStorage = BazelInfoStorage(bspInfo)
             val bazelDataResolver =
                 BazelInfoResolver(
-                    BazelRunner.of(workspaceContextProvider, bspClientLogger, workspaceRoot),
+                    bazelRunner,
                     bazelInfoStorage
                 )
             val bazelInfo = bazelDataResolver.resolveBazelInfo()
 
-            val bazelRunner = BazelRunner.of(
-                workspaceContextProvider, bspClientLogger, bazelInfo.workspaceRoot
-            )
-            val compilationManager = BazelBspCompilationManager(bazelRunner)
             val aspectsResolver = InternalAspectsResolver(bspInfo)
             val bazelBspAspectsManager = BazelBspAspectsManager(compilationManager, aspectsResolver)
             val bazelPathsResolver = BazelPathsResolver(bazelInfo)

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticBspMapper.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticBspMapper.kt
@@ -9,8 +9,9 @@ import ch.epfl.scala.bsp4j.PublishDiagnosticsParams
 import ch.epfl.scala.bsp4j.TextDocumentIdentifier
 import java.nio.file.Paths
 import org.jetbrains.bsp.bazel.bazelrunner.BazelInfo
+import java.nio.file.Path
 
-class DiagnosticBspMapper(private val bazelInfo: BazelInfo) {
+class DiagnosticBspMapper(private val workspaceRoot: Path) {
 
     fun createDiagnostics(diagnostics: List<Diagnostic>, originId: String?): List<PublishDiagnosticsParams> {
         return diagnostics
@@ -39,7 +40,7 @@ class DiagnosticBspMapper(private val bazelInfo: BazelInfo) {
     private fun toAbsoluteUri(rawFileLocation: String): String {
         var path = Paths.get(rawFileLocation)
         if (!path.isAbsolute) {
-            path = bazelInfo.workspaceRoot.resolve(path)
+            path = workspaceRoot.resolve(path)
         }
         return path.toUri().toString()
     }

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsService.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsService.kt
@@ -2,11 +2,12 @@ package org.jetbrains.bsp.bazel.server.diagnostics
 
 import ch.epfl.scala.bsp4j.PublishDiagnosticsParams
 import org.jetbrains.bsp.bazel.bazelrunner.BazelInfo
+import java.nio.file.Path
 
-class DiagnosticsService(bazelInfo: BazelInfo) {
+class DiagnosticsService(workspaceRoot: Path) {
 
     private val parser = DiagnosticsParser()
-    private val mapper = DiagnosticBspMapper(bazelInfo)
+    private val mapper = DiagnosticBspMapper(workspaceRoot)
 
     fun extractDiagnostics(
         bazelOutput: String,

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsServiceTest.kt
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsServiceTest.kt
@@ -525,7 +525,6 @@ class DiagnosticsServiceTest {
     }
 
     private fun extractDiagnostics(output: String, buildTarget: String): List<PublishDiagnosticsParams>? {
-        val bazelInfo = BasicBazelInfo("", workspacePath)
-        return DiagnosticsService(bazelInfo).extractDiagnostics(output, buildTarget, null)
+        return DiagnosticsService(workspacePath).extractDiagnostics(output, buildTarget, null)
     }
 }


### PR DESCRIPTION
Before this change, `bazel info` was called before the actual BSP
server. This means, there was no clear way to submit failure (for
example if `bazel` executable was not available in PATH). Currently,
it is run on `build/intitialize` request, so the error will be logged
via BSP failure response.