### PR TITLE
Refactor get/set for JavaModule

### DIFF
--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bloop/BspProjectExporter.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bloop/BspProjectExporter.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.bsp.bazel.server.bloop
 
-import org.jetbrains.bsp.bazel.server.sync.languages.LanguageData
 import org.jetbrains.bsp.bazel.server.sync.languages.java.JavaModule
+import org.jetbrains.bsp.bazel.server.sync.languages.jvm.javaModule
 import org.jetbrains.bsp.bazel.server.sync.languages.scala.ScalaModule
 import org.jetbrains.bsp.bazel.server.sync.model.Module
 import org.jetbrains.bsp.bazel.server.sync.model.Project
@@ -37,15 +37,15 @@ internal class BspProjectExporter(private val project: Project, private val bloo
     private fun buildClassPathRewriter(): ClasspathRewriter {
         val localArtifactsBuilder = project.modules.flatMap {
             val moduleOutput = classesOutputForModule(it, bloopRoot)
-            it.languageData?.let(::artifactsFromLanguageData)?.map { uri ->
+            artifactsFromLanguageData(it).map { uri ->
                 uri to moduleOutput
-            }.orEmpty()
+            }
         }.toMap()
         return ClasspathRewriter(localArtifactsBuilder)
     }
 
-    private fun artifactsFromLanguageData(languageData: LanguageData): Set<URI> {
-        return JavaModule.fromLanguageData(languageData)
+    private fun artifactsFromLanguageData(module: Module): Set<URI> {
+        return module.javaModule
             ?.let(JavaModule::allOutputs)
             ?.toSet().orEmpty()
     }

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/BspProjectMapper.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/BspProjectMapper.kt
@@ -41,6 +41,7 @@ import ch.epfl.scala.bsp4j.TestProvider
 import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult
 import org.jetbrains.bsp.bazel.commons.Constants
 import org.jetbrains.bsp.bazel.server.sync.languages.LanguagePluginsService
+import org.jetbrains.bsp.bazel.server.sync.languages.jvm.javaModule
 import org.jetbrains.bsp.bazel.server.sync.model.Label
 import org.jetbrains.bsp.bazel.server.sync.model.Language
 import org.jetbrains.bsp.bazel.server.sync.model.Module
@@ -211,11 +212,8 @@ class BspProjectMapper(
     }
 
     private fun extractJvmEnvironmentItem(module: Module): JvmEnvironmentItem? =
-        languagePluginsService.extractJavaModule(module)?.let {
-            languagePluginsService.javaLanguagePlugin.toJvmEnvironmentItem(
-                module,
-                it
-            )
+        module.javaModule?.let {
+            languagePluginsService.javaLanguagePlugin.toJvmEnvironmentItem(module, it)
         }
 
     fun buildTargetJavacOptions(project: Project, params: JavacOptionsParams): JavacOptionsResult {
@@ -237,7 +235,7 @@ class BspProjectMapper(
 
 
     private fun extractJavacOptionsItem(module: Module): JavacOptionsItem? =
-        languagePluginsService.extractJavaModule(module)?.let {
+        module.javaModule?.let {
             languagePluginsService.javaLanguagePlugin.toJavacOptionsItem(module, it)
         }
 

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/LanguagePluginsService.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/LanguagePluginsService.kt
@@ -4,9 +4,7 @@ import org.jetbrains.bsp.bazel.info.BspTargetInfo
 import org.jetbrains.bsp.bazel.server.sync.languages.cpp.CppLanguagePlugin
 import org.jetbrains.bsp.bazel.server.sync.languages.cpp.CppModule
 import org.jetbrains.bsp.bazel.server.sync.languages.java.JavaLanguagePlugin
-import org.jetbrains.bsp.bazel.server.sync.languages.java.JavaModule
 import org.jetbrains.bsp.bazel.server.sync.languages.scala.ScalaLanguagePlugin
-import org.jetbrains.bsp.bazel.server.sync.languages.scala.ScalaModule
 import org.jetbrains.bsp.bazel.server.sync.languages.thrift.ThriftLanguagePlugin
 import org.jetbrains.bsp.bazel.server.sync.model.Language
 import org.jetbrains.bsp.bazel.server.sync.model.Module
@@ -33,15 +31,6 @@ class LanguagePluginsService(
             languages.contains(Language.CPP) -> cppLanguagePlugin
             languages.contains(Language.THRIFT) -> thriftLanguagePlugin
             else -> emptyLanguagePlugin
-        }
-
-    fun extractJavaModule(module: Module): JavaModule? =
-        module.languageData?.let {
-            when (it) {
-                is JavaModule -> it
-                is ScalaModule -> it.javaModule
-                else -> null
-            }
         }
 
     fun extractCppModule(module: Module): CppModule? =

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/java/JavaModule.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/java/JavaModule.kt
@@ -22,14 +22,4 @@ data class JavaModule(
     val compileClasspath: List<URI>,
     val sourcesClasspath: List<URI>,
     val ideClasspath: List<URI>
-) : LanguageData {
-
-    companion object {
-        @JvmStatic
-        fun fromLanguageData(languageData: LanguageData?): JavaModule? = when (languageData) {
-            is JavaModule -> languageData
-            is ScalaModule -> languageData.javaModule
-            else -> null
-        }
-    }
-}
+) : LanguageData

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/jvm/JvmModule.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/jvm/JvmModule.kt
@@ -1,0 +1,23 @@
+package org.jetbrains.bsp.bazel.server.sync.languages.jvm
+
+import org.jetbrains.bsp.bazel.server.sync.model.Module
+import org.jetbrains.bsp.bazel.server.sync.languages.java.JavaModule
+import org.jetbrains.bsp.bazel.server.sync.languages.scala.ScalaModule
+
+
+val Module.javaModule: JavaModule?
+    get() {
+        return when (languageData) {
+            is JavaModule -> languageData
+            is ScalaModule -> languageData.javaModule
+            else -> null
+        }
+    }
+
+fun Module.withJavaModule(javaModule: JavaModule): Module {
+    return when (languageData) {
+        is JavaModule -> this.copy(languageData = javaModule)
+        is ScalaModule -> this.copy(languageData = languageData.copy(javaModule = javaModule))
+        else -> this
+    }
+}


### PR DESCRIPTION
It is a prerequisite for my further work.
This PR helps to treat all jvm targets (currently java and scala) in a unified way in terms of their common data, i.e. get and "set" JavaModule.