### PR TITLE
[feature] exclude bazel-* symlinks

### DIFF
--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/BspServerApi.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/BspServerApi.java
@@ -170,10 +170,9 @@ public class BspServerApi
   }
 
   @Override
-  public CompletableFuture<OutputPathsResult> buildTargetOutputPaths(
-      OutputPathsParams params) {
+  public CompletableFuture<OutputPathsResult> buildTargetOutputPaths(OutputPathsParams params) {
     return runner.handleRequest(
-            "buildTargetOutputPaths", projectSyncService::buildTargetOutputPaths, params);
+        "buildTargetOutputPaths", projectSyncService::buildTargetOutputPaths, params);
   }
 
   @Override

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/BspServerApi.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/BspServerApi.java
@@ -171,9 +171,9 @@ public class BspServerApi
 
   @Override
   public CompletableFuture<OutputPathsResult> buildTargetOutputPaths(
-      OutputPathsParams outputPathsParams) {
-    // TODO: https://youtrack.jetbrains.com/issue/BAZEL-240
-    return CompletableFuture.failedFuture(new Exception("This endpoint is not implemented yet"));
+      OutputPathsParams params) {
+    return runner.handleRequest(
+            "buildTargetOutputPaths", projectSyncService::buildTargetOutputPaths, params);
   }
 
   @Override

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/IntelliJProjectTreeViewFix.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/IntelliJProjectTreeViewFix.kt
@@ -35,7 +35,7 @@ class IntelliJProjectTreeViewFix(
     }
 
     private fun isFullWorkspaceImport(workspaceContext: WorkspaceContext, workspaceRoot: URI): Boolean {
-        return importTargetSpecs(workspaceContext).any { it.startsWith("//...") } ||
+        return importTargetSpecs(workspaceContext).any { it.startsWith("//...") || it.startsWith("@//...") } ||
                 workspaceContext.dotBazelBspDirPath.value.parent.toUri() == workspaceRoot
     }
 

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/ProjectSyncService.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/ProjectSyncService.java
@@ -15,8 +15,8 @@ import ch.epfl.scala.bsp4j.JvmRunEnvironmentParams;
 import ch.epfl.scala.bsp4j.JvmRunEnvironmentResult;
 import ch.epfl.scala.bsp4j.JvmTestEnvironmentParams;
 import ch.epfl.scala.bsp4j.JvmTestEnvironmentResult;
-import ch.epfl.scala.bsp4j.OutputPathsResult;
 import ch.epfl.scala.bsp4j.OutputPathsParams;
+import ch.epfl.scala.bsp4j.OutputPathsResult;
 import ch.epfl.scala.bsp4j.ResourcesParams;
 import ch.epfl.scala.bsp4j.ResourcesResult;
 import ch.epfl.scala.bsp4j.ScalaMainClassesParams;
@@ -125,5 +125,4 @@ public class ProjectSyncService {
   public DependencyModulesResult buildTargetDependencyModules(DependencyModulesParams params) {
     return new DependencyModulesResult(Collections.emptyList());
   }
-
 }

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/ProjectSyncService.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/ProjectSyncService.java
@@ -15,6 +15,8 @@ import ch.epfl.scala.bsp4j.JvmRunEnvironmentParams;
 import ch.epfl.scala.bsp4j.JvmRunEnvironmentResult;
 import ch.epfl.scala.bsp4j.JvmTestEnvironmentParams;
 import ch.epfl.scala.bsp4j.JvmTestEnvironmentResult;
+import ch.epfl.scala.bsp4j.OutputPathsResult;
+import ch.epfl.scala.bsp4j.OutputPathsParams;
 import ch.epfl.scala.bsp4j.ResourcesParams;
 import ch.epfl.scala.bsp4j.ResourcesResult;
 import ch.epfl.scala.bsp4j.ScalaMainClassesParams;
@@ -77,6 +79,11 @@ public class ProjectSyncService {
     return bspMapper.dependencySources(project, dependencySourcesParams);
   }
 
+  public OutputPathsResult buildTargetOutputPaths(OutputPathsParams params) {
+    var project = projectProvider.get();
+    return bspMapper.outputPaths(project, params);
+  }
+
   public JvmRunEnvironmentResult jvmRunEnvironment(JvmRunEnvironmentParams params) {
     var project = projectProvider.get();
     return bspMapper.jvmRunEnvironment(project, params);
@@ -118,4 +125,5 @@ public class ProjectSyncService {
   public DependencyModulesResult buildTargetDependencyModules(DependencyModulesParams params) {
     return new DependencyModulesResult(Collections.emptyList());
   }
+
 }

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/model/Module.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/model/Module.kt
@@ -13,6 +13,7 @@ data class Module(
     val baseDirectory: URI,
     val sourceSet: SourceSet,
     val resources: Set<URI>,
+    val outputs: Set<URI>,
     val sourceDependencies: Set<URI>,
     val languageData: LanguageData?,
     val environmentVariables: Map<String, String>

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/bloop/BspModuleExporterTest.kt
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/bloop/BspModuleExporterTest.kt
@@ -37,6 +37,7 @@ class BspModuleExporterTest {
             ),
             emptySet(),
             emptySet(),
+            emptySet(),
             ScalaModule(
                 ScalaSdk("scala", "2.12.15", "2.12.15", emptyList()), emptyList(), JavaModule(
                     Jdk("11", null),

--- a/server/src/test/java/org/jetbrains/bsp/bazel/server/sync/ProjectStorageTest.kt
+++ b/server/src/test/java/org/jetbrains/bsp/bazel/server/sync/ProjectStorageTest.kt
@@ -59,6 +59,7 @@ class ProjectStorageTest {
                     ),
                     emptySet(),
                     emptySet(),
+                    emptySet(),
                     scalaModule,
                     hashMapOf()
                 )


### PR DESCRIPTION
I implemented the unused endpoint outputPaths.
 
It would now be possible to add outputs for each module, though it doesn't make much sense for bazel, but maybe some day we will find a use for it.

Currently are outputs are treated as directories, it can be changed easily when we find another use case for this endpoint that would need files.

I am detecting if workspace root will be visible in IntelliJ (either whole workspace is imported or bsp server is setup at workspace root), if so, we return a synthetic module at workspace root with single resource root pointing to the workspace and 4 output directories pointing to the problematic symlinks.