### PR TITLE
[change] Initialize the hash sets with the number of elements they are expected to hold

### DIFF
--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/BepOutput.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/BepOutput.java
@@ -33,9 +33,9 @@ public class BepOutput {
       return Collections.emptySet();
     }
 
-    var result = new HashSet<URI>();
+    var result = new HashSet<URI>(rootIds.size());
     var toVisit = Queues.newArrayDeque(rootIds);
-    var visited = new HashSet<String>();
+    var visited = new HashSet<String>(rootIds.size());
 
     while (!toVisit.isEmpty()) {
       var fileSetId = toVisit.remove();


### PR DESCRIPTION
This saves about 10 seconds when refreshing a test project with 10 thousand empty targets.