### PR TITLE
[change] Don't request the "bsp-ide-resolve-transitive-deps" output group when running the bsp_target_info_aspect.

### DIFF
--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/ProjectResolver.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/ProjectResolver.kt
@@ -50,13 +50,12 @@ class ProjectResolver(
         bazelBspAspectsManager.fetchFilesFromOutputGroups(
             workspaceContext.targets,
             ASPECT_NAME,
-            listOf(BSP_INFO_OUTPUT_GROUP, ARTIFACTS_OUTPUT_GROUP)
+            listOf(BSP_INFO_OUTPUT_GROUP)
         )
 
 
     companion object {
         private const val ASPECT_NAME = "bsp_target_info_aspect"
         private const val BSP_INFO_OUTPUT_GROUP = "bsp-target-info-transitive-deps"
-        private const val ARTIFACTS_OUTPUT_GROUP = "bsp-ide-resolve-transitive-deps"
     }
 }


### PR DESCRIPTION
Upon receiving the `workspace/buildTargets` request, the server runs a Bazel aspect to retrieve the data about the project structure. We used to request two output groups, namely `bsp-target-info-transitive-deps` and `bsp-ide-resolve-transitive-deps`. It turns out that the files produced by the latter one are never used, so we might as well drop it.

This change should greatly speed up importing fresh projects, because requesting `bsp-ide-resolve-transitive-deps` causes source jars to be built. On a sample project with 10 000 empty Java targets, the duration of fresh import has decreased from about 300 seconds to less than 90 seconds.