### PR TITLE
[fix] Add class jars generated during annotation processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## [Unreleased]
 
+### Fixes
+-  Add class jars generated during annotation processing
+  | [#372](https://github.com/JetBrains/bazel-bsp/pull/372)
+
 ## [2.6.1]
 
 ### SECURITY 🚨

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/java/JavaLanguagePlugin.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/java/JavaLanguagePlugin.kt
@@ -40,7 +40,7 @@ class JavaLanguagePlugin(
             }.map(bazelPathsResolver::resolveUri)
             val mainClass = getMainClass(this)
             val runtimeClasspath = bazelPathsResolver.resolveUris(runtimeClasspathList)
-            val compileClasspath = bazelPathsResolver.resolveUris(compileClasspathList)
+            val compileClasspath = bazelPathsResolver.resolveUris(compileClasspathList + generatedJarsList.flatMap { it.binaryJarsList })
             val sourcesClasspath = bazelPathsResolver.resolveUris(sourceClasspathList)
             val ideClasspath = resolveIdeClasspath(Label(targetInfo.id),
                 bazelPathsResolver,


### PR DESCRIPTION
It would also be possible to pass source jars, but there's no clear way how it should be handled in BSP

https://bazel.build/rules/lib/JavaInfo#JavaInfo