### PR TITLE
[maintenance] Update docs how to use projectview | #BAZEL-377 Done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   | [#372](https://github.com/JetBrains/bazel-bsp/pull/372)
 - Set PublishDiagnosticsParams.reset to be true
   | [#377](https://github.com/JetBrains/bazel-bsp/pull/377)
+- Update document about how to use projectview
+  | [#383](https://github.com/JetBrains/bazel-bsp/pull/383)
 
 ## [2.6.1]
 

--- a/executioncontext/projectview/README.md
+++ b/executioncontext/projectview/README.md
@@ -17,7 +17,8 @@ from [Bazel Plugin for Intellij](https://ij.bazel.build/docs/project-views.html)
 
 **Note:** We will be changing this mechanism in future releases.
 
-Simply put `projectview.bazelproject` file in the root of your project and fill it.
+`$ cs launch org.jetbrains.bsp:bazel-bsp:<version> -M org.jetbrains.bsp.bazel.install.Install -- -p <path/to/projectview_file>`.
+For more details, see `--help`.
 
 ## Available sections
 


### PR DESCRIPTION
This PR update the instruction how to use projectview, since bazel-bsp newbie (me 😅 ) misunderstood that `bazel-bsp` will automatically read the `projectview.bazelproject` file.

closing https://youtrack.jetbrains.com/issue/BAZEL-377