### PR TITLE
[maintenance] GH actions update

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,17 +5,6 @@ on:
     branches: [ dev, master ]
 
 jobs:
-  google-java-format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: "11"
-      - uses: axel-op/googlejavaformat-action@v3
-        with:
-          skipCommit: true
-      - run: git diff --exit-code
   buildifier:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,7 +7,7 @@ on:
     branches: [ dev, master ]
 
 jobs:
-  commons-test:
+  unit-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -16,37 +16,4 @@ jobs:
         with:
           java-version: 11
       - name: Run tests
-        run: bazel test //commons/...
-
-#  bazelrunner-test:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v1
-#        with:
-#          java-version: 11
-#      - name: Run tests
-#        run: bazel test //bazelrunner/...
-
-  executioncontext-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      - name: Run tests
-        run: bazel test //executioncontext/...
-
-  server-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      - name: Run tests
-        run: bazel test //server/...
+        run: bazel test //...


### PR DESCRIPTION
- java format out
- just unit tests instead of separate per module

GH actions are deprecated anyway since we are migrating to TC, but we need it for a while anyway