### PR TITLE
[maintenance] add grouping for dependencies that share version in Bazel Steward

### DIFF
--- a/bazel-steward.yaml
+++ b/bazel-steward.yaml
@@ -1,2 +1,12 @@
 pull-requests:
+  - group-id: log4j
+    dependencies: "org.apache.logging.log4j:*"
+  - group-id: jackson
+    dependencies: "com.fasterxml.jackson*:*"
+  - group-id: grpc
+    dependencies: "io.grpc:*"
+  - group-id: junit-jupiter
+    dependencies: "org.junit.jupiter:*"
+  - group-id: kotest
+    dependencies: "io.kotest:*"
   - title: "[maintenance] updated ${dependencyId} to ${versionTo}"


### PR DESCRIPTION
This will use new Bazel Steward feature that creates one PR for group of dependencies.