### PR TITLE
[fix] prioritize most frequently used JDKs when selecting the project JDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 
 ## [Unreleased]
+### Fixes 🛠️
+-  Prioritize most frequently used JDKs when selecting the project JDK. 
+   | [#420](https://github.com/JetBrains/bazel-bsp/pull/420)
 
 ## [2.7.0]
 

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/java/JdkResolver.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/java/JdkResolver.kt
@@ -11,7 +11,7 @@ class JdkResolver(
 ) {
 
   fun resolve(targets: Sequence<TargetInfo>): Jdk? {
-    val allCandidates = targets.mapNotNull { resolveJdkData(it) }.distinct().map { JdkCandidate(it) }
+    val allCandidates = targets.mapNotNull { resolveJdkData(it) }.sortByFrequency().map { JdkCandidate(it) }
     if (allCandidates.none()) return null
     val latestVersion = candidatesWithLatestVersion(allCandidates)
     val complete = allCandidates.filter { it.isComplete }
@@ -33,7 +33,6 @@ class JdkResolver(
       findLatestVersion(candidates)
         ?.let { version -> candidates.filter { it.version == version } }
         .orEmpty()
-        .sortedBy { it.javaHome.toString() } // for predictable results
 
   private fun findLatestVersion(candidates: Sequence<JdkCandidate>): String? =
       candidates.mapNotNull { it.version }.maxByOrNull { Integer.parseInt(it) }
@@ -75,5 +74,11 @@ class JdkResolver(
       val isRuntime: Boolean,
       val javaHome: URI?,
   )
+
+private fun <A> Sequence<A>.sortByFrequency(): Sequence<A> =
+      groupBy { it }.values
+        .sortedByDescending { it.size }
+        .map { it.first() }
+        .asSequence()
 
 }


### PR DESCRIPTION
Currently JDKs are sorted lexicographically by java home for determinism. Sometimes it can be a problem. when there are 2 JDKs found and one of them is used in nearly all targets and one is used in a few docker related targets that are not relevant. If alphabet is not on your side, you get the wrong JDK (for example wrong architecture) that is not even fetched/resolved fully. 
Since JDK resolving is still a heuristic in bazel-bsp, this change should give more useful results usually.