### PR TITLE
[fix] set uncaught execution handlers in executor services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
    | [#420](https://github.com/JetBrains/bazel-bsp/pull/420)
 -  Fix ide classpath computation for recent rules_jvm_external.
    | [#421](https://github.com/JetBrains/bazel-bsp/pull/421)
+-  Process exit instead of hang in case of uncaught exception in pooled threads
+   | [#425](https://github.com/JetBrains/bazel-bsp/pull/425)
 
 ## [2.7.0]
 

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BUILD
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/managers/BUILD
@@ -12,6 +12,7 @@ java_library(
         "//server/src/main/java/org/jetbrains/bsp/bazel/server/bsp/utils",
         "//server/src/main/java/org/jetbrains/bsp/bazel/server/diagnostics",
         "@io_bazel//third_party/grpc:grpc-jar_checked_in",
+        "@maven//:com_google_guava_guava",
         "@maven//:org_eclipse_lsp4j_org_eclipse_lsp4j_jsonrpc",
     ],
 )


### PR DESCRIPTION
Otherwise, an executor service could crash (for example due to OutOfMemory exception) without calling process exit, so as a result the process would hang.