### PR TITLE
[performance] Do not hold all output files of the project in memory a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 
 ## [Unreleased]
-
+### Performance
+-  Reduce peak memory footprint
+   | [#428](https://github.com/JetBrains/bazel-bsp/pull/428)
 ## [2.7.1]
 
 ### Fixes 🛠️

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/BepOutput.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/BepOutput.java
@@ -1,9 +1,7 @@
 package org.jetbrains.bsp.bazel.server.bep;
 
 import com.google.common.collect.Queues;
-import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -11,15 +9,15 @@ import java.util.Set;
 
 public class BepOutput {
   private final Map<String, Set<String>> outputGroups;
-  private final Map<String, BuildEventStreamProtos.NamedSetOfFiles> fileSets;
+  private final Map<String, TextProtoDepSet> textProtoFileSets;
   private final Set<String> rootTargets;
 
   public BepOutput(
       Map<String, Set<String>> outputGroups,
-      Map<String, BuildEventStreamProtos.NamedSetOfFiles> fileSets,
+      Map<String, TextProtoDepSet> textProtoFileSets,
       Set<String> rootTargets) {
     this.outputGroups = outputGroups;
-    this.fileSets = fileSets;
+    this.textProtoFileSets = textProtoFileSets;
     this.rootTargets = rootTargets;
   }
 
@@ -39,28 +37,15 @@ public class BepOutput {
 
     while (!toVisit.isEmpty()) {
       var fileSetId = toVisit.remove();
-      var fileSet = fileSets.get(fileSetId);
+      var fileSet = textProtoFileSets.get(fileSetId);
 
-      fileSet.getFilesList().stream()
-          .map(s -> uncheckedURICreation(s.getUri()))
-          .forEach(result::add);
+      result.addAll(fileSet.getFiles());
       visited.add(fileSetId);
 
-      var children = fileSet.getFileSetsList();
-      children.stream()
-          .map(BuildEventStreamProtos.BuildEventId.NamedSetOfFilesId::getId)
-          .filter(child -> !visited.contains(child))
-          .forEach(toVisit::add);
+      var children = fileSet.getChildren();
+      children.stream().filter(child -> !visited.contains(child)).forEach(toVisit::add);
     }
 
     return result;
-  }
-
-  private URI uncheckedURICreation(String s) {
-    try {
-      return new URI(s);
-    } catch (URISyntaxException ignored) {
-    }
-    return null;
   }
 }

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/TextProtoDepSet.java
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/bep/TextProtoDepSet.java
@@ -1,0 +1,22 @@
+package org.jetbrains.bsp.bazel.server.bep;
+
+import java.net.URI;
+import java.util.Collection;
+
+public class TextProtoDepSet {
+  private final Collection<URI> files;
+  private final Collection<String> children;
+
+  TextProtoDepSet(Collection<URI> files, Collection<String> children) {
+    this.files = files;
+    this.children = children;
+  }
+
+  public Collection<URI> getFiles() {
+    return files;
+  }
+
+  public Collection<String> getChildren() {
+    return children;
+  }
+}


### PR DESCRIPTION
…t once

Previously, we've been catching all NamedSetOfFiles messages that came over BEP in BepOutput.fileSets data structure. This meant we stored *all* output file paths of the project there, while the only purpose of it was to retrieve *.bsp-info.textproto files.

Since now, we filter-out all other file kinds.