### PR TITLE
[fix] collect scalac options from toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 
 ## [Unreleased]
+
+### Fixes 🛠️
+- Collect scalac options from the toolchain
+   | [#433](https://github.com/JetBrains/bazel-bsp/pull/433)
+
 ### Performance
 -  Reduce peak memory footprint
    | [#428](https://github.com/JetBrains/bazel-bsp/pull/428)
+
 ## [2.7.1]
 
 ### Fixes 🛠️


### PR DESCRIPTION
Before this PR, scalac options were only loaded from the rule attributes. Options in the toolchain are then merged in one of rules_scala phases with these options for rules and then target is compiled. 
In short, when global opts are set in toolchain, we don't pick them up.

They are only available in toolchain, but there is no way to get to it (`_scala_toolchain` attribute is not actually the toolchain, but some compiler jars). Only way to get to it is to add it to the toolchains attribute of the aspect, which breaks on workspaces without rules_scala. 
Until preprocessor for aspect file or a plugin system is developed, we can't properly implement it.

I've put the proper implementation in the comment for someone migrating this in the future. 

I found a workaround to inspect the compile action of a target. The argv of the commanad that builds it is running a scala worker that takes --ScalacOpts as a parameter. We can borrow it from there.