### PR TITLE
[fix] now server can obtain scala3 compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 ### Fixes 🛠️
 
-- aspects dont fail if target contains another target as `srcs` attribute
+- aspects don't fail if target contains another target as `srcs` attribute
+- now server can obtain scala 3 compiler
 
 ## [3.0.0] - 09.08.2023
 

--- a/aspects/rules/scala/scala_info.bzl
+++ b/aspects/rules/scala/scala_info.bzl
@@ -6,7 +6,7 @@ def find_scalac_classpath(runfiles):
     found_scala_compiler_jar = False
     for file in runfiles:
         name = file.basename
-        if file.extension == "jar" and ("scala3-compiler" or "scala-compiler") in name:
+        if file.extension == "jar" and ("scala3-compiler" in name or "scala-compiler" in name):
             found_scala_compiler_jar = True
             result.append(file)
         elif file.extension == "jar" and ("scala3-library" in name or "scala3-reflect" in name or "scala-library" in name or "scala-reflect" in name):

--- a/aspects/rules/scala/scala_info.bzl
+++ b/aspects/rules/scala/scala_info.bzl
@@ -6,12 +6,12 @@ def find_scalac_classpath(runfiles):
     found_scala_compiler_jar = False
     for file in runfiles:
         name = file.basename
-        if file.extension == "jar" and "scala-compiler" in name:
+        if file.extension == "jar" and ("scala3-compiler" or "scala-compiler") in name:
             found_scala_compiler_jar = True
             result.append(file)
-        elif file.extension == "jar" and ("scala-library" in name or "scala-reflect" in name):
+        elif file.extension == "jar" and ("scala3-library" in name or "scala3-reflect" in name or "scala-library" in name or "scala-reflect" in name):
             result.append(file)
-    return result if found_scala_compiler_jar and len(result) >= 3 else []
+    return result if found_scala_compiler_jar and len(result) >= 2 else []
 
 def extract_scala_toolchain_info(target, ctx, output_groups, **kwargs):
     runfiles = target.default_runfiles.files.to_list()

--- a/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaSdkResolver.kt
+++ b/server/src/main/java/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaSdkResolver.kt
@@ -58,6 +58,6 @@ class ScalaSdkResolver(private val bazelPathsResolver: BazelPathsResolver) {
             0
         }
         private val VERSION_PATTERN =
-            Pattern.compile("(?:processed_)?scala-(?:library|compiler|reflect)-([.\\d]+)\\.jar")
+            Pattern.compile("(?:processed_)?scala3?-(?:library|compiler|reflect)(?:_3)?-([.\\d]+)\\.jar")
     }
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/BAZEL-404/Bazel-Bsp-with-scala-3.1.0-Failed-to-resolve-Scala-SDK-for-project

the solution is kinda ugly, but we will be changing the lang support soon and then we will have to handle all the scala 3 things more gracefully