### PR TITLE
[maintenance] update quick start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Bazel.
 2. Run in the directory where Bazel BSP should be installed:
 
 ```shell
-cs launch org.jetbrains.bsp:bazel-bsp:<version> -M org.jetbrains.bsp.bazel.install.Install
+cs launch org.jetbrains.bsp:bazel-bsp:<version> -M org.jetbrains.bsp.bazel.install.Install -- --targets //...
 ```
 
 Please check [release](https://github.com/JetBrains/bazel-bsp/releases) to find the newest available version


### PR DESCRIPTION
After 3.0 update the default for targets changed from all to none, which is quite confusing, especially for people who approach this server for the first time.

I propose to extend the example command like I did in this PR, so that user knows how to include all targets or easily adjust it to a different scope. It has the added benefit of showing that `--` is needed to pass arguments to the server.

Alternatively, you may want to clearly mention that one has to open the generated project view and add the desired targets. Current state of readme suggests that it is optional thing.