### PR TITLE
resource collection also needs to be gated by type

### DIFF
--- a/aspects/core.bzl
+++ b/aspects/core.bzl
@@ -131,11 +131,15 @@ def _bsp_target_info_aspect_impl(target, ctx):
             if f.is_source
         ]
 
-    resources = [
-        file_location(f)
-        for t in getattr(ctx.rule.attr, "resources", [])
-        for f in t.files.to_list()
-    ]
+    resources_attr = getattr(ctx.rule.attr, "resources", [])
+    resources = []
+
+    if type(resources_attr) == "list":
+        resources = [
+            file_location(f)
+            for t in resources_attr
+            for f in t.files.to_list()
+        ]
 
     aspect_ids = get_aspect_ids(ctx, target)
 


### PR DESCRIPTION
I was seeing an exception when loading the project that string could not be cast to list. We use the resources attribute for some macros as a string which causes problems here.