### PR TITLE
[feature] add data to taskStart and taskFinished

### DIFF
--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bep/BepServer.java
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bep/BepServer.java
@@ -1,10 +1,15 @@
 package org.jetbrains.bsp.bazel.server.bep;
 
 import ch.epfl.scala.bsp4j.BuildClient;
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import ch.epfl.scala.bsp4j.CompileReport;
+import ch.epfl.scala.bsp4j.CompileTask;
 import ch.epfl.scala.bsp4j.StatusCode;
 import ch.epfl.scala.bsp4j.TaskFinishParams;
+import ch.epfl.scala.bsp4j.TaskFinishDataKind;
 import ch.epfl.scala.bsp4j.TaskId;
 import ch.epfl.scala.bsp4j.TaskStartParams;
+import ch.epfl.scala.bsp4j.TaskStartDataKind;
 import ch.epfl.scala.bsp4j.TextDocumentIdentifier;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
 import com.google.devtools.build.v1.BuildEvent;
@@ -46,9 +51,12 @@ public class BepServer extends PublishBuildEventGrpc.PublishBuildEventImplBase {
   private final DiagnosticsService diagnosticsService;
   private BepOutputBuilder bepOutputBuilder = new BepOutputBuilder();
 
+  private final Optional<BuildTargetIdentifier> target;
+
   public BepServer(
-      BuildClient bspClient, DiagnosticsService diagnosticsService, Optional<String> originId) {
+      BuildClient bspClient, DiagnosticsService diagnosticsService, Optional<String> originId, Optional<BuildTargetIdentifier> target) {
     this.bspClient = bspClient;
+    this.target = target;
     this.diagnosticsService = diagnosticsService;
     this.originId = originId;
     this.bepLogger = new BepLogger(bspClient, originId);
@@ -58,8 +66,9 @@ public class BepServer extends PublishBuildEventGrpc.PublishBuildEventImplBase {
       BuildClient client,
       Path workspaceRoot,
       Map<String, Set<TextDocumentIdentifier>> hasAnyProblems,
-      Optional<String> originId) {
-    return new BepServer(client, new DiagnosticsService(workspaceRoot, hasAnyProblems), originId);
+      Optional<String> originId,
+      Optional<BuildTargetIdentifier> target) {
+    return new BepServer(client, new DiagnosticsService(workspaceRoot, hasAnyProblems), originId, target);
   }
 
   @Override
@@ -132,6 +141,11 @@ public class BepServer extends PublishBuildEventGrpc.PublishBuildEventImplBase {
     TaskStartParams startParams = new TaskStartParams(taskId);
     startParams.setEventTime(buildStarted.getStartTimeMillis());
 
+    if (target.isPresent()) {
+      startParams.setDataKind(TaskStartDataKind.COMPILE_TASK);
+      CompileTask task = new CompileTask(target.get());
+      startParams.setData(task);
+    }
     bspClient.onBuildTaskStart(startParams);
     startedEvents.push(new AbstractMap.SimpleEntry<>(taskId, originId));
   }
@@ -156,6 +170,14 @@ public class BepServer extends PublishBuildEventGrpc.PublishBuildEventImplBase {
     StatusCode exitCode = ExitCodeMapper.mapExitCode(buildFinished.getExitCode().getCode());
     TaskFinishParams finishParams = new TaskFinishParams(startedEvents.pop().getKey(), exitCode);
     finishParams.setEventTime(buildFinished.getFinishTimeMillis());
+
+    if (target.isPresent()) {
+      finishParams.setDataKind(TaskFinishDataKind.COMPILE_REPORT);
+      var isSuccess = exitCode.getValue() == 1;
+      var errors = isSuccess ? 0 : 1;
+      CompileReport report = new CompileReport(target.get(), errors, 0);
+      finishParams.setData(report);
+    }
     bspClient.onBuildTaskFinish(finishParams);
   }
 
@@ -210,7 +232,10 @@ public class BepServer extends PublishBuildEventGrpc.PublishBuildEventImplBase {
     var outputGroups = targetComplete.getOutputGroupList();
     LOGGER.trace("Consuming target completed event " + targetComplete);
     bepOutputBuilder.storeTargetOutputGroups(label, outputGroups);
-    if (targetComplete.getSuccess()) {
+
+    // We should clear diagnostics only on completed successful compilation
+    var shouldClearDiagnostics = outputGroups.stream().anyMatch(group -> group.getName().equals("default"));
+    if (targetComplete.getSuccess() && shouldClearDiagnostics) {
       // clear former diagnostics by publishing an empty array of diagnostics
       // why we do this on `target_completed` instead of `action_completed`?
       // because `action_completed` won't be published on build success for a target.

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspCompilationManager.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspCompilationManager.kt
@@ -27,7 +27,8 @@ class BazelBspCompilationManager(
         extraFlags: List<String>,
         originId: String?,
     ): BepBuildResult {
-        val bepServer = BepServer.newBepServer(client, workspaceRoot, hasAnyProblems, Optional.ofNullable(originId))
+        val target = targetSpecs.values.firstOrNull()
+        val bepServer = BepServer.newBepServer(client, workspaceRoot, hasAnyProblems, Optional.ofNullable(originId), Optional.ofNullable(target))
         val bepReader = BepReader(bepServer)
         return try {
             bepReader.start()

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ExecuteService.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ExecuteService.kt
@@ -47,7 +47,7 @@ class ExecuteService(
     }
 
     private fun <T> withBepServer(body : (BepReader) -> T): T {
-        val server = BepServer.newBepServer(compilationManager.client, compilationManager.workspaceRoot, hasAnyProblems, Optional.empty())
+        val server = BepServer.newBepServer(compilationManager.client, compilationManager.workspaceRoot, hasAnyProblems, Optional.empty(), Optional.empty())
         val bepReader = BepReader(server)
         return body(bepReader)
     }


### PR DESCRIPTION
Metals uses this information for managing compilations. Also moves clearing diagnostics from `targetComplete` to `taskFinished`