### PR TITLE
[fix] Fix issue if classpath query returns more results

### DIFF
--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ClasspathQuery.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ClasspathQuery.kt
@@ -2,6 +2,7 @@ package org.jetbrains.bsp.bazel.server.sync
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
 import org.eclipse.lsp4j.jsonrpc.CancelChecker
 import org.jetbrains.bsp.bazel.bazelrunner.BazelRunner
 import org.jetbrains.bsp.bazel.server.bsp.info.BspInfo
@@ -15,8 +16,17 @@ object ClasspathQuery {
                 .executeBazelCommand(parseProcessOutput = false)
                 .waitAndGetResult(cancelChecker, ensureAllOutputRead = true)
         if (cqueryResult.isNotSuccess) throw RuntimeException("Could not query target '${target.uri}' for runtime classpath")
-        val classpaths = Gson().fromJson(cqueryResult.stdout, JvmClasspath::class.java)
-        return classpaths
+        try {
+            val classpaths = Gson().fromJson(cqueryResult.stdout, JvmClasspath::class.java)
+            return classpaths
+        } catch (e: JsonSyntaxException){
+            // sometimes Bazel returns two values to a query when multiple configurations apply to a target
+            return if (cqueryResult.stdoutLines.size > 1) {
+                val allOpts = cqueryResult.stdoutLines.map { Gson().fromJson(it, JvmClasspath::class.java) }
+                allOpts.maxByOrNull { it.runtime_classpath.size + it.compile_classpath.size }!!
+            }
+            else throw e
+        }
     }
 
     data class JvmClasspath (


### PR DESCRIPTION
Previously, if this happened, we would not get any results to a query as two json results line by line are not valid json.

I am not 100% why this happens, one classpath seems to have paths starting with `bazel-out/k8-fastbuild/bin` and the other with `bazel-out/host/bin`, which I don't really understand, but this should be a good enough workaround

Alternatively, I could just return empty, but in any case we should handle the exception I think.