### PR TITLE
bugfix: Cache classpath information in proto files

### DIFF
--- a/aspects/rules/jvm/jvm_info.bzl
+++ b/aspects/rules/jvm/jvm_info.bzl
@@ -156,6 +156,8 @@ def extract_jvm_info(target, ctx, output_groups, **kwargs):
         main_class = main_class,
         args = args,
         jdeps = [file_location(j) for j in jdeps],
+        runtime_jars = [jar.path for jar in extract_runtime_jars(target, provider).to_list()],
+        compile_jars = [jar.path for jar in extract_compile_jars(provider).to_list()],
     )
 
     return create_proto(target, ctx, info, "jvm_target_info"), None

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/BazelProjectMapper.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/BazelProjectMapper.kt
@@ -415,6 +415,8 @@ class BazelProjectMapper(
       sourceDependencies = sourceDependencies,
       languageData = languageData,
       environmentVariables = environment,
+      runtimeClasspath = target.jvmTargetInfo.runtimeJarsList,
+      compileClasspath = target.jvmTargetInfo.compileJarsList,
     )
   }
 

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ClasspathQuery.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ClasspathQuery.kt
@@ -2,10 +2,12 @@ package org.jetbrains.bsp.bazel.server.sync
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import com.google.gson.Gson
+import com.google.gson.stream.MalformedJsonException
 import org.eclipse.lsp4j.jsonrpc.CancelChecker
 import org.jetbrains.bsp.bazel.bazelrunner.BazelRunner
 import org.jetbrains.bsp.bazel.server.bsp.info.BspInfo
 
+// TODO maybe remove
 object ClasspathQuery {
     fun classPathQuery(target: BuildTargetIdentifier, cancelChecker: CancelChecker, bspInfo: BspInfo, bazelRunner: BazelRunner): JvmClasspath {
         val queryFile = bspInfo.bazelBspDir().resolve("aspects/runtime_classpath_query.bzl")
@@ -15,8 +17,14 @@ object ClasspathQuery {
                 .executeBazelCommand(parseProcessOutput = false)
                 .waitAndGetResult(cancelChecker, ensureAllOutputRead = true)
         if (cqueryResult.isNotSuccess) throw RuntimeException("Could not query target '${target.uri}' for runtime classpath")
-        val classpaths = Gson().fromJson(cqueryResult.stdout, JvmClasspath::class.java)
-        return classpaths
+        try {
+            val classpaths = Gson().fromJson(cqueryResult.stdout, JvmClasspath::class.java)
+            return classpaths
+        } catch (e: MalformedJsonException){
+            // sometimes Bazel returns two values to a query, which are not parseable, the real query should be oneline
+            return if (cqueryResult.stdoutLines.size > 1) Gson().fromJson(cqueryResult.stdoutLines[0], JvmClasspath::class.java)
+            else JvmClasspath(emptyList(), emptyList())
+        }
     }
 
     data class JvmClasspath (

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/model/Module.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/model/Module.kt
@@ -15,5 +15,7 @@ data class Module(
     val outputs: Set<URI>,
     val sourceDependencies: Set<URI>,
     val languageData: LanguageData?,
-    val environmentVariables: Map<String, String>
+    val environmentVariables: Map<String, String>,
+    val runtimeClasspath: List<String>,
+    val compileClasspath: List<String>,
 )

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/proto/bsp_target_info.proto
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/proto/bsp_target_info.proto
@@ -35,6 +35,8 @@ message JvmTargetInfo {
   string main_class = 8;
   repeated string args = 9;
   repeated FileLocation jdeps = 10;
+  repeated string runtime_jars = 11;
+  repeated string compile_jars = 12;
 }
 
 message JavaToolchainInfo {


### PR DESCRIPTION
Previously, when scalacOptions or javacOptions was queried we would also query each target's classpath, which would take around 0.5 for a target, which means users would need to wait much longer for a fully functional workspace.

Now, we cache the classpath information together with all other jvm information, which makes it all much faster.

This also fixes the issue in https://github.com/JetBrains/bazel-bsp/pull/519