### PR TITLE
bugfix: Fix the @@ prefix issue if bazel.module and WORKSPACE are used together

### DIFF
--- a/bazelrunner/src/main/kotlin/org/jetbrains/bsp/bazel/bazelrunner/BazelInfo.kt
+++ b/bazelrunner/src/main/kotlin/org/jetbrains/bsp/bazel/bazelrunner/BazelInfo.kt
@@ -16,12 +16,10 @@ data class BazelRelease(
   val major: Int
 ) {
 
-  fun mainRepositoryReferencePrefix(isBzlModEnabled: Boolean) = when (major) {
+  fun mainRepositoryReferencePrefix() = when (major) {
     in 0..3 -> throw RuntimeException("Unsupported Bazel version, use Bazel 4 or newer")
     in 4..5 -> "//"
-    else ->
-      if (isBzlModEnabled) "@@//"
-      else "@//"
+    else -> "@//"
   }
 
   companion object {

--- a/bazelrunner/src/test/kotlin/org/jetbrains/bsp/bazel/bazelrunner/BazelReleaseTest.kt
+++ b/bazelrunner/src/test/kotlin/org/jetbrains/bsp/bazel/bazelrunner/BazelReleaseTest.kt
@@ -17,7 +17,7 @@ class BazelReleaseTest {
 
     // then
     release?.major shouldBe 4
-    release?.mainRepositoryReferencePrefix(false) shouldBe "//"
+    release?.mainRepositoryReferencePrefix() shouldBe "//"
   }
 
   @Test
@@ -27,7 +27,7 @@ class BazelReleaseTest {
 
     // then
     release?.major shouldBe 6
-    release?.mainRepositoryReferencePrefix(false) shouldBe "@//"
+    release?.mainRepositoryReferencePrefix() shouldBe "@//"
   }
 
   @Test

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/paths/BazelPathsResolver.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/paths/BazelPathsResolver.kt
@@ -90,7 +90,7 @@ class BazelPathsResolver(private val bazelInfo: BazelInfo) {
         Paths.get(bazelInfo.execRoot, path)
 
     fun isRelativeWorkspacePath(label: String): Boolean {
-        val prefix = bazelInfo.release.mainRepositoryReferencePrefix(bazelInfo.isBzlModEnabled)
+        val prefix = bazelInfo.release.mainRepositoryReferencePrefix()
         return label.startsWith(prefix)
     }
 
@@ -107,7 +107,7 @@ class BazelPathsResolver(private val bazelInfo: BazelInfo) {
     }
 
     fun extractRelativePath(label: String): String {
-        val prefix = bazelInfo.release.mainRepositoryReferencePrefix(bazelInfo.isBzlModEnabled)
+        val prefix = bazelInfo.release.mainRepositoryReferencePrefix()
 
         require(isRelativeWorkspacePath(label)) { "$label didn't start with $prefix" }
         val labelWithoutPrefix = label.substring(prefix.length)

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/BazelProjectMapper.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/BazelProjectMapper.kt
@@ -349,7 +349,7 @@ class BazelProjectMapper(
     }
 
   private fun isWorkspaceTarget(target: TargetInfo): Boolean =
-    target.id.startsWith(bazelInfo.release.mainRepositoryReferencePrefix(bazelInfo.isBzlModEnabled)) &&
+    target.id.startsWith(bazelInfo.release.mainRepositoryReferencePrefix()) &&
       (hasKnownSources(target) ||
         target.kind in setOf(
         "java_library",
@@ -504,7 +504,7 @@ class BazelProjectMapper(
     targetInfo.envInheritList.associateWith { System.getenv(it) }
 
   private fun removeDotBazelBspTarget(targets: List<String>): List<String> {
-    val prefix = bazelInfo.release.mainRepositoryReferencePrefix(bazelInfo.isBzlModEnabled) + ".bazelbsp"
+    val prefix = bazelInfo.release.mainRepositoryReferencePrefix() + ".bazelbsp"
     return targets.filter { !it.startsWith(prefix) }
   }
 

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ProjectResolver.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ProjectResolver.kt
@@ -68,7 +68,7 @@ class ProjectResolver(
     val rootTargets = buildAspectResult.bepOutput.rootTargets().let { formatTargetsIfNeeded(it) }
     val targets = measured(
       "Parsing aspect outputs"
-    ) { targetInfoReader.readTargetMapFromAspectOutputs(aspectOutputs) }
+    ) { targetInfoReader.readTargetMapFromAspectOutputs(aspectOutputs).let { it.mapKeys { it.key.replace("@@", "@") } } }
     return measured(
       "Mapping to internal model"
     ) { bazelProjectMapper.createProject(targets, rootTargets.toSet(), allTargetNames, workspaceContext, bazelInfo) }
@@ -88,10 +88,7 @@ class ProjectResolver(
       // contrary to "//"-prefixed in older Bazel versions. Unfortunately this does not apply
       // to BEP data, probably due to a bug, so we need to add the "@" prefix here.
       in 0..5 -> targets.toList()
-      else ->
-        if (bazelInfo.isBzlModEnabled)
-          targets.map { "@@$it" }
-        else targets.map { "@$it" }
+      else -> targets.map { "@$it" }
     }.toList()
 
   companion object {


### PR DESCRIPTION
It's not uncommon to have both BAZEL.module file and WORKSPACE, in that case Bazel BSP will not detect all targets, or in case of the repository I am working on it would detect none of them.

There doesn't seem to be any actual way to discover if a target should have a @ or @@ prefix, so instead I changed the behaviour to replace @@ with @, which should work in most cases.