### PR TITLE
[fix] fix the `@@` prefix issue if `bazel.module` and `WORKSPACE` are used together

### DIFF
--- a/bazelrunner/src/main/kotlin/org/jetbrains/bsp/bazel/bazelrunner/BazelInfo.kt
+++ b/bazelrunner/src/main/kotlin/org/jetbrains/bsp/bazel/bazelrunner/BazelInfo.kt
@@ -16,12 +16,16 @@ data class BazelRelease(
   val major: Int
 ) {
 
-  fun mainRepositoryReferencePrefix(isBzlModEnabled: Boolean) = when (major) {
+  fun isRelativeWorkspacePath(label: String) = when (major) {
     in 0..3 -> throw RuntimeException("Unsupported Bazel version, use Bazel 4 or newer")
-    in 4..5 -> "//"
-    else ->
-      if (isBzlModEnabled) "@@//"
-      else "@//"
+    in 4..5 -> label.startsWith("//")
+    else -> label.startsWith("@//") || label.startsWith("@@//")
+  }
+
+  fun stripPrefix(label: String) = when (major) {
+    in 0..3 -> throw RuntimeException("Unsupported Bazel version, use Bazel 4 or newer")
+    in 4..5 -> label.removePrefix("//")
+    else -> label.dropWhile { it == '@' }.removePrefix("//")
   }
 
   companion object {

--- a/bazelrunner/src/test/kotlin/org/jetbrains/bsp/bazel/bazelrunner/BazelReleaseTest.kt
+++ b/bazelrunner/src/test/kotlin/org/jetbrains/bsp/bazel/bazelrunner/BazelReleaseTest.kt
@@ -17,7 +17,7 @@ class BazelReleaseTest {
 
     // then
     release?.major shouldBe 4
-    release?.mainRepositoryReferencePrefix(false) shouldBe "//"
+    release?.isRelativeWorkspacePath("//abc") shouldBe true
   }
 
   @Test
@@ -27,7 +27,8 @@ class BazelReleaseTest {
 
     // then
     release?.major shouldBe 6
-    release?.mainRepositoryReferencePrefix(false) shouldBe "@//"
+    release?.isRelativeWorkspacePath("@//abc") shouldBe true
+    release?.isRelativeWorkspacePath("@@//abc") shouldBe true
   }
 
   @Test

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/paths/BazelPathsResolver.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/paths/BazelPathsResolver.kt
@@ -90,8 +90,7 @@ class BazelPathsResolver(private val bazelInfo: BazelInfo) {
         Paths.get(bazelInfo.execRoot, path)
 
     fun isRelativeWorkspacePath(label: String): Boolean {
-        val prefix = bazelInfo.release.mainRepositoryReferencePrefix(bazelInfo.isBzlModEnabled)
-        return label.startsWith(prefix)
+        return bazelInfo.release.isRelativeWorkspacePath(label)
     }
 
     fun extractExternalPath(label: String): String {
@@ -107,10 +106,9 @@ class BazelPathsResolver(private val bazelInfo: BazelInfo) {
     }
 
     fun extractRelativePath(label: String): String {
-        val prefix = bazelInfo.release.mainRepositoryReferencePrefix(bazelInfo.isBzlModEnabled)
 
-        require(isRelativeWorkspacePath(label)) { "$label didn't start with $prefix" }
-        val labelWithoutPrefix = label.substring(prefix.length)
+        require(bazelInfo.release.isRelativeWorkspacePath(label)) { "$label didn't start with correct prefix" }
+        val labelWithoutPrefix = bazelInfo.release.stripPrefix(label)
         val parts = labelWithoutPrefix.split(":".toRegex()).toTypedArray()
         require(parts.size == 2) { "Label $label didn't contain exactly one ':'" }
         return parts[0]

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/BazelProjectMapper.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/BazelProjectMapper.kt
@@ -363,7 +363,7 @@ class BazelProjectMapper(
     }
 
   private fun isWorkspaceTarget(target: TargetInfo): Boolean =
-    target.id.startsWith(bazelInfo.release.mainRepositoryReferencePrefix(bazelInfo.isBzlModEnabled)) &&
+    bazelInfo.release.isRelativeWorkspacePath(target.id) &&
       (hasKnownSources(target) ||
         target.kind in setOf(
         "java_library",
@@ -518,8 +518,7 @@ class BazelProjectMapper(
     targetInfo.envInheritList.associateWith { System.getenv(it) }
 
   private fun removeDotBazelBspTarget(targets: List<String>): List<String> {
-    val prefix = bazelInfo.release.mainRepositoryReferencePrefix(bazelInfo.isBzlModEnabled) + ".bazelbsp"
-    return targets.filter { !it.startsWith(prefix) }
+    return targets.filter { bazelInfo.release.isRelativeWorkspacePath(it) && !bazelInfo.release.stripPrefix(it).startsWith(".bazelbsp") }
   }
 
   private fun createRustExternalModules(


### PR DESCRIPTION
Second attempt, this time I changed it to looks for the actual @@ or @ label to be available.