### PR TITLE
feature: Add dependencyModules request support

### DIFF
--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/BspProjectMapper.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/BspProjectMapper.kt
@@ -7,6 +7,11 @@ import ch.epfl.scala.bsp4j.CompileProvider
 import ch.epfl.scala.bsp4j.CppOptionsItem
 import ch.epfl.scala.bsp4j.CppOptionsParams
 import ch.epfl.scala.bsp4j.CppOptionsResult
+import ch.epfl.scala.bsp4j.DependencyModule
+import ch.epfl.scala.bsp4j.DependencyModuleDataKind
+import ch.epfl.scala.bsp4j.DependencyModulesItem
+import ch.epfl.scala.bsp4j.DependencyModulesParams
+import ch.epfl.scala.bsp4j.DependencyModulesResult
 import ch.epfl.scala.bsp4j.DependencySourcesItem
 import ch.epfl.scala.bsp4j.DependencySourcesParams
 import ch.epfl.scala.bsp4j.DependencySourcesResult
@@ -22,6 +27,8 @@ import ch.epfl.scala.bsp4j.JvmRunEnvironmentParams
 import ch.epfl.scala.bsp4j.JvmRunEnvironmentResult
 import ch.epfl.scala.bsp4j.JvmTestEnvironmentParams
 import ch.epfl.scala.bsp4j.JvmTestEnvironmentResult
+import ch.epfl.scala.bsp4j.MavenDependencyModule
+import ch.epfl.scala.bsp4j.MavenDependencyModuleArtifact
 import ch.epfl.scala.bsp4j.OutputPathItem
 import ch.epfl.scala.bsp4j.OutputPathItemKind
 import ch.epfl.scala.bsp4j.OutputPathsItem
@@ -71,6 +78,7 @@ import org.jetbrains.bsp.bazel.server.sync.languages.jvm.javaModule
 import org.jetbrains.bsp.bazel.server.sync.languages.scala.ScalaModule
 import org.jetbrains.bsp.bazel.server.sync.model.Label
 import org.jetbrains.bsp.bazel.server.sync.model.Language
+import org.jetbrains.bsp.bazel.server.sync.model.Library
 import org.jetbrains.bsp.bazel.server.sync.model.Module
 import org.jetbrains.bsp.bazel.server.sync.model.Project
 import org.jetbrains.bsp.bazel.server.sync.model.Tag
@@ -78,6 +86,7 @@ import org.jetbrains.bsp.bazel.workspacecontext.WorkspaceContextProvider
 import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.LinkedList
 import kotlin.io.path.exists
 import kotlin.io.path.name
 import kotlin.io.path.relativeToOrNull
@@ -445,6 +454,62 @@ class BspProjectMapper(
         val scalaLanguagePlugin = languagePluginsService.scalaLanguagePlugin
         val items = modules.mapNotNull(scalaLanguagePlugin::toScalaMainClassesItem)
         return ScalaMainClassesResult(items)
+    }
+
+    private fun extractMavenDependencyInfo(lib: Library): MavenDependencyModule? {
+        val jars = lib.outputs.map { uri -> uri.toString() }.map {
+            MavenDependencyModuleArtifact(it)
+        }
+        val sourceJars = lib.sources.map { uri -> uri.toString() }.map {
+            val artifact = MavenDependencyModuleArtifact(it)
+            artifact.classifier = "sources"
+            artifact
+        }
+
+        // Matches the Maven group (organization), artifact, and version in the Bazel dependency
+        // string such as .../execroot/monorepo/bazel-out/k8-fastbuild/bin/external/maven/com/google/guava/guava/31.1-jre/processed_guava-31.1-jre.jar
+        val regexPattern = """.*/maven/(.+)/([^/]+)/([^/]+)/[^/]+.jar""".toRegex()
+        val dependencyPath = lib.outputs.first().toString()
+        // Find matches in the dependency path
+        val matchResult = regexPattern.find(dependencyPath)
+
+        // If a match is found, group values are extracted; otherwise, null is returned
+        return matchResult?.let {
+            val (organization, artifact, version) = it.destructured
+            MavenDependencyModule(organization.replace("/", "."), artifact, version, jars + sourceJars)
+        }
+    }
+
+   private fun allModuleDependencies(project: Project, module: Module): HashSet<Library> {
+        val toResolve = LinkedList<String>()
+        toResolve.addAll(module.directDependencies.map { it.value })
+        val accumulator = HashSet<Library>()
+        while (toResolve.isNotEmpty()){
+            val lib = project.libraries[toResolve.pop()]
+            if (lib != null && !accumulator.contains(lib)) {
+                accumulator.add(lib)
+                toResolve.addAll(lib.dependencies)
+            }
+        }
+        return accumulator
+    }
+
+    fun buildDependencyModules(project: Project, params: DependencyModulesParams): DependencyModulesResult {
+        val targetSet = params.targets.toSet()
+        val dependencyModulesItems = project.modules.filter { targetSet.contains(BuildTargetIdentifier(it.label.value)) }.map { module ->
+            val buildTargetId = BuildTargetIdentifier(module.label.value)
+            val moduleItems = allModuleDependencies(project, module).map { libraryDep ->
+                val mavenDependencyModule = if (libraryDep.outputs.isNotEmpty()) extractMavenDependencyInfo(libraryDep) else null
+                val dependencyModule = DependencyModule(libraryDep.label, mavenDependencyModule?.version ?: "")
+                if (mavenDependencyModule != null) {
+                    dependencyModule.data = mavenDependencyModule
+                    dependencyModule.dataKind = DependencyModuleDataKind.MAVEN
+                }
+                dependencyModule
+            }
+            DependencyModulesItem(buildTargetId, moduleItems)
+        }
+        return DependencyModulesResult(dependencyModulesItems)
     }
 
     fun rustWorkspace(

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/BspProjectMapper.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/BspProjectMapper.kt
@@ -27,8 +27,6 @@ import ch.epfl.scala.bsp4j.JvmRunEnvironmentParams
 import ch.epfl.scala.bsp4j.JvmRunEnvironmentResult
 import ch.epfl.scala.bsp4j.JvmTestEnvironmentParams
 import ch.epfl.scala.bsp4j.JvmTestEnvironmentResult
-import ch.epfl.scala.bsp4j.MavenDependencyModule
-import ch.epfl.scala.bsp4j.MavenDependencyModuleArtifact
 import ch.epfl.scala.bsp4j.OutputPathItem
 import ch.epfl.scala.bsp4j.OutputPathItemKind
 import ch.epfl.scala.bsp4j.OutputPathsItem
@@ -78,7 +76,6 @@ import org.jetbrains.bsp.bazel.server.sync.languages.jvm.javaModule
 import org.jetbrains.bsp.bazel.server.sync.languages.scala.ScalaModule
 import org.jetbrains.bsp.bazel.server.sync.model.Label
 import org.jetbrains.bsp.bazel.server.sync.model.Language
-import org.jetbrains.bsp.bazel.server.sync.model.Library
 import org.jetbrains.bsp.bazel.server.sync.model.Module
 import org.jetbrains.bsp.bazel.server.sync.model.Project
 import org.jetbrains.bsp.bazel.server.sync.model.Tag
@@ -86,9 +83,7 @@ import org.jetbrains.bsp.bazel.workspacecontext.WorkspaceContextProvider
 import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.LinkedList
 import kotlin.io.path.exists
-import java.util.*
 import kotlin.io.path.name
 import kotlin.io.path.relativeToOrNull
 import kotlin.io.path.toPath

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/DependencyMapper.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/DependencyMapper.kt
@@ -6,7 +6,6 @@ import org.jetbrains.bsp.bazel.server.sync.model.Library
 import org.jetbrains.bsp.bazel.server.sync.model.Module
 import org.jetbrains.bsp.bazel.server.sync.model.Project
 import java.util.*
-import kotlin.collections.HashSet
 
 object DependencyMapper {
 
@@ -20,18 +19,26 @@ object DependencyMapper {
             artifact.classifier = "sources"
             artifact
         }
-
+        /* For example:
+         * @@rules_jvm_external~override~maven~maven//:org_apache_commons_commons_lang3
+         * @maven//:org_scala_lang_scala_library
+         **/
+        val orgStart = lib.label.split("//:").lastOrNull()?.split('_')?.firstOrNull() ?: "org"
         // Matches the Maven group (organization), artifact, and version in the Bazel dependency
         // string such as .../execroot/monorepo/bazel-out/k8-fastbuild/bin/external/maven/com/google/guava/guava/31.1-jre/processed_guava-31.1-jre.jar
-        val regexPattern = """.*/maven/(.+)/([^/]+)/([^/]+)/[^/]+.jar""".toRegex()
-        val dependencyPath = lib.outputs.first().toString()
+        // bazel-out/k8-fastbuild/bin/external/rules_jvm_external~~maven~name/v1/https/repo1.maven.org/maven2/com/google/auto/service/auto-service-annotations/1.1.1/header_auto-service-annotations-1.1.1.jar
+        val regexPattern = """.*/($orgStart/.+)/([^/]+)/([^/]+)/[^/]+.jar""".toRegex()
+        val dependencyPath = lib.outputs.firstOrNull()?.toString()
         // Find matches in the dependency path
-        val matchResult = regexPattern.find(dependencyPath)
-
-        // If a match is found, group values are extracted; otherwise, null is returned
-        return matchResult?.let {
-            val (organization, artifact, version) = it.destructured
-            MavenDependencyModule(organization.replace("/", "."), artifact, version, jars + sourceJars)
+        if (dependencyPath != null) {
+            val matchResult = regexPattern.find(dependencyPath)
+            // If a match is found, group values are extracted; otherwise, null is returned
+            return matchResult?.let {
+                val (organization, artifact, version) = it.destructured
+                MavenDependencyModule(organization.replace("/", "."), artifact, version, jars + sourceJars)
+            }
+        } else {
+            return null
         }
     }
 
@@ -40,7 +47,7 @@ object DependencyMapper {
         val toResolve = LinkedList<String>()
         toResolve.addAll(module.directDependencies.map { it.value })
         val accumulator = HashSet<Library>()
-        while (toResolve.isNotEmpty()){
+        while (toResolve.isNotEmpty()) {
             val lib = project.libraries[toResolve.pop()]
             if (lib != null && !accumulator.contains(lib)) {
                 accumulator.add(lib)

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/DependencyMapper.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/DependencyMapper.kt
@@ -1,0 +1,52 @@
+package org.jetbrains.bsp.bazel.server.sync
+
+import ch.epfl.scala.bsp4j.MavenDependencyModule
+import ch.epfl.scala.bsp4j.MavenDependencyModuleArtifact
+import org.jetbrains.bsp.bazel.server.sync.model.Library
+import org.jetbrains.bsp.bazel.server.sync.model.Module
+import org.jetbrains.bsp.bazel.server.sync.model.Project
+import java.util.*
+import kotlin.collections.HashSet
+
+object DependencyMapper {
+
+    fun extractMavenDependencyInfo(lib: Library): MavenDependencyModule? {
+        if (lib.outputs.isEmpty()) return null
+        val jars = lib.outputs.map { uri -> uri.toString() }.map {
+            MavenDependencyModuleArtifact(it)
+        }
+        val sourceJars = lib.sources.map { uri -> uri.toString() }.map {
+            val artifact = MavenDependencyModuleArtifact(it)
+            artifact.classifier = "sources"
+            artifact
+        }
+
+        // Matches the Maven group (organization), artifact, and version in the Bazel dependency
+        // string such as .../execroot/monorepo/bazel-out/k8-fastbuild/bin/external/maven/com/google/guava/guava/31.1-jre/processed_guava-31.1-jre.jar
+        val regexPattern = """.*/maven/(.+)/([^/]+)/([^/]+)/[^/]+.jar""".toRegex()
+        val dependencyPath = lib.outputs.first().toString()
+        // Find matches in the dependency path
+        val matchResult = regexPattern.find(dependencyPath)
+
+        // If a match is found, group values are extracted; otherwise, null is returned
+        return matchResult?.let {
+            val (organization, artifact, version) = it.destructured
+            MavenDependencyModule(organization.replace("/", "."), artifact, version, jars + sourceJars)
+        }
+    }
+
+
+    fun allModuleDependencies(project: Project, module: Module): HashSet<Library> {
+        val toResolve = LinkedList<String>()
+        toResolve.addAll(module.directDependencies.map { it.value })
+        val accumulator = HashSet<Library>()
+        while (toResolve.isNotEmpty()){
+            val lib = project.libraries[toResolve.pop()]
+            if (lib != null && !accumulator.contains(lib)) {
+                accumulator.add(lib)
+                toResolve.addAll(lib.dependencies)
+            }
+        }
+        return accumulator
+    }
+}

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ProjectSyncService.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ProjectSyncService.kt
@@ -160,8 +160,8 @@ class ProjectSyncService(private val bspMapper: BspProjectMapper, private val pr
     cancelChecker: CancelChecker,
     params: DependencyModulesParams
   ): DependencyModulesResult {
-    // TODO https://youtrack.jetbrains.com/issue/BAZEL-616
-    return DependencyModulesResult(emptyList())
+    val project = projectProvider.get(cancelChecker)
+    return bspMapper.buildDependencyModules(project, params)
   }
 
   fun rustWorkspace(

--- a/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/sync/BUILD
+++ b/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/sync/BUILD
@@ -18,3 +18,12 @@ kt_test(
         "//server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync",
     ],
 )
+
+kt_test(
+    name = "DependencyMapperTest",
+    size = "small",
+    src = "DependencyMapperTest.kt",
+    deps = [
+        "//server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync",
+    ],
+)

--- a/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/sync/DependencyMapperTest.kt
+++ b/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/sync/DependencyMapperTest.kt
@@ -1,0 +1,104 @@
+package org.jetbrains.bsp.bazel.server.sync
+
+import ch.epfl.scala.bsp4j.MavenDependencyModule
+import ch.epfl.scala.bsp4j.MavenDependencyModuleArtifact
+import io.kotest.matchers.shouldBe
+import org.jetbrains.bsp.bazel.bazelrunner.BazelRelease
+import org.jetbrains.bsp.bazel.server.sync.model.Label
+import org.jetbrains.bsp.bazel.server.sync.model.Library
+import org.jetbrains.bsp.bazel.server.sync.model.Module
+import org.jetbrains.bsp.bazel.server.sync.model.Project
+import org.jetbrains.bsp.bazel.server.sync.model.SourceSet
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.nio.file.Paths
+
+class DependencyMapperTest {
+
+    private val cacheLocation = "file:///home/user/.cache/bazel/_bazel_user/ae7b7b315151086e31e3b97f9ddba009/execroot/monorepo/bazel-out/k8-fastbuild-ST-4a519fd6d3e4"
+
+    @Test
+    fun `should translate dependency`() {
+        val jarUri = URI.create("$cacheLocation/bin/external/maven/org/scala-lang/scala-library/2.13.11/processed_scala-library-2.13.11.jar")
+        val jarSourcesUri = URI.create("$cacheLocation/bin/external/maven/org/scala-lang/scala-library/2.13.11/scala-library-2.13.11-sources.jar")
+        val lib1 = Library(
+            "@maven//:org_scala_lang_scala_library",
+            setOf(jarUri),
+            setOf(jarSourcesUri),
+            emptyList()
+        )
+        val expectedMavenArtifact = MavenDependencyModuleArtifact(jarUri.toString())
+        val expectedMavenSourcesArtifact = MavenDependencyModuleArtifact(jarSourcesUri.toString())
+        expectedMavenSourcesArtifact.classifier = "sources"
+        val expectedDependency = MavenDependencyModule("org.scala-lang", "scala-library", "2.13.11", listOf(
+            expectedMavenArtifact,
+            expectedMavenSourcesArtifact
+        ))
+        val dependency = DependencyMapper.extractMavenDependencyInfo(lib1)
+
+        dependency shouldBe expectedDependency
+    }
+
+    @Test
+    fun `should not translate non maven dependency`() {
+        val lib1 = Library(
+            "@//projects/v1:scheduler",
+            emptySet(),
+            emptySet(),
+            emptyList()
+        )
+        val dependency = DependencyMapper.extractMavenDependencyInfo(lib1)
+
+        dependency shouldBe null
+    }
+
+    @Test
+    fun `should gather deps transitively`() {
+        val jarUri = URI.create("$cacheLocation/bin/external/maven/org/scala-lang/scala-library/2.13.11/processed_scala-library-2.13.11.jar")
+        val jarSourcesUri = URI.create("$cacheLocation/bin/external/maven/org/scala-lang/scala-library/2.13.11/scala-library-2.13.11-sources.jar")
+        val lib1 = Library(
+            "@maven//:org_scala_lang_scala_library",
+            setOf(jarUri),
+            setOf(jarSourcesUri),
+            emptyList()
+        )
+        val lib2 = Library(
+            "@maven//:org_scala_lang_scala_library2",
+            emptySet(),
+            emptySet(),
+            listOf(lib1.label)
+        )
+        val lib3 = Library(
+            "@maven//:org_scala_lang_scala_library3",
+            emptySet(),
+            emptySet(),
+            listOf(lib1.label, lib2.label)
+        )
+        val lib4 = Library(
+            "@maven//:org_scala_lang_scala_library4",
+            emptySet(),
+            emptySet(),
+            listOf(lib3.label, lib2.label)
+        )
+        val libraries = mapOf(lib1.label to lib1, lib2.label to lib2, lib3.label to lib3, lib4.label to lib4)
+        val currentUri = Paths.get(".").toUri()
+        val project = Project(currentUri, emptyList(), emptyMap(), libraries, emptyList(), BazelRelease(6))
+        val module = Module(
+            Label(""),
+            true,
+            listOf(Label(lib4.label)),
+            emptySet(),
+            emptySet(),
+            currentUri,
+            SourceSet(emptySet(), emptySet()),
+            emptySet(),
+            emptySet(),
+            emptySet(),
+            null,
+            emptyMap()
+        )
+        val foundLibraries = DependencyMapper.allModuleDependencies(project, module)
+
+        foundLibraries shouldBe setOf(lib1, lib2, lib3, lib4)
+    }
+}

--- a/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/sync/DependencyMapperTest.kt
+++ b/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/sync/DependencyMapperTest.kt
@@ -40,6 +40,28 @@ class DependencyMapperTest {
     }
 
     @Test
+    fun `should bazelmod translate dependency`() {
+        val jarUri = URI.create("$cacheLocation/bin/external/rules_jvm_external~~maven~name/v1/https/repo1.maven.org/maven2/com/google/auto/service/auto-service-annotations/1.1.1/header_auto-service-annotations-1.1.1.jar")
+        val jarSourcesUri = URI.create("$cacheLocation/bin/external/rules_jvm_external~~maven~name/v1/https/repo1.maven.org/maven2/com/google/auto/service/auto-service-annotations/1.1.1/header_auto-service-annotations-1.1.1-sources.jar")
+        val lib1 = Library(
+            "@@rules_jvm_external~override~maven~maven//:com_google_auto_service_auto_service_annotations",
+            setOf(jarUri),
+            setOf(jarSourcesUri),
+            emptyList()
+        )
+        val expectedMavenArtifact = MavenDependencyModuleArtifact(jarUri.toString())
+        val expectedMavenSourcesArtifact = MavenDependencyModuleArtifact(jarSourcesUri.toString())
+        expectedMavenSourcesArtifact.classifier = "sources"
+        val expectedDependency = MavenDependencyModule("com.google.auto.service", "auto-service-annotations", "1.1.1", listOf(
+            expectedMavenArtifact,
+            expectedMavenSourcesArtifact
+        ))
+        val dependency = DependencyMapper.extractMavenDependencyInfo(lib1)
+
+        dependency shouldBe expectedDependency
+    }
+
+    @Test
     fun `should not translate non maven dependency`() {
         val lib1 = Library(
             "@//projects/v1:scheduler",


### PR DESCRIPTION
This would be super useful to use as an alternative to libraries request, which is not standard BSP request.

Tests depends on https://github.com/build-server-protocol/bsp-testkit2/pull/41