### PR TITLE
bugfix: Fix showing Scala 3 diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@
   | [1c51f02](https://github.com/JetBrains/bazel-bsp/commit/1c51f02a4331c331a0d7d4cc412bfd1e36daf77e)
 - Server adds sources to generated libs.
   | [eaa5161](https://github.com/JetBrains/bazel-bsp/commit/eaa5161fe4193268c21c324f27786f5f17f79afd)
+- Support Scala 3 diagnostics.
+  | [744735f](https://github.com/JetBrains/bazel-bsp/commit/744735ff30c96f218414514e99019c8ffc700dfe)
 
 ## [3.0.0] - 09.08.2023
 

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/BazelRootMessageParser.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/BazelRootMessageParser.kt
@@ -56,5 +56,5 @@ object BazelRootMessageParser : Parser {
   }
 
   private fun collectCompilerDiagnostics(output: Output) =
-      generateSequence { CompilerDiagnosticParser.tryParseOne(output) }.toList()
+      generateSequence { CompilerDiagnosticParser.tryParseOne(output) ?: Scala3CompilerDiagnosticParser.tryParseOne(output) }.toList()
 }

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsParser.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsParser.kt
@@ -51,6 +51,7 @@ class DiagnosticsParser {
     private val Parsers = listOf(
         BazelRootMessageParser,
         CompilerDiagnosticParser,
+        Scala3CompilerDiagnosticParser,
         AllCatchParser
     )
     private val IgnoredLines = listOf(

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/Scala3CompilerDiagnosticParser.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/Scala3CompilerDiagnosticParser.kt
@@ -1,0 +1,55 @@
+package org.jetbrains.bsp.bazel.server.diagnostics
+
+object Scala3CompilerDiagnosticParser : Parser {
+
+    override fun tryParse(output: Output): List<Diagnostic> =
+        listOfNotNull(tryParseOne(output))
+
+    private val DiagnosticHeader = """
+      ^--\       # "-- " diagnostic start 
+      \[E\d+\]   # "[E008]" code 
+      ([^:]+): # (1) type of diagnostic
+      ([^:]+):(\d+):(\d+) # (2) path, (3) line, (4) column
+      \ \-+$ # " -----------------" ending 
+      """.toRegex(RegexOption.COMMENTS)
+
+    // Scala 3 diagnostics have additional color printed, since Bazel uses renderedMessage field
+    private val colorRegex = "\u001b\\[1A\u001b\\[K|\u001B\\[[;\\d]*m".toRegex()
+
+    fun tryTake(output: Output, regex: Regex): MatchResult? =
+        output.peek()?.let { regex.matchEntire(it.replace(colorRegex, "")) }?.also { output.take() }
+
+    fun tryParseOne(output: Output): Diagnostic? {
+        return tryTake(output, DiagnosticHeader)
+            ?.let { match ->
+                val level = if (match.groupValues[1].contains("Error")) Level.Error else Level.Warning
+                val path = match.groupValues[2].trim()
+                val line = match.groupValues[3].toInt()
+                val messageLines = collectMessageLines(match.groupValues[1].trim(), output)
+                val column = match.groupValues[4].toIntOrNull() ?: tryFindColumnNumber(messageLines) ?: 1
+                val message = messageLines.joinToString("\n")
+                Diagnostic(Position(line, column), message, level, path, output.targetLabel)
+            }
+    }
+
+    private fun collectMessageLines(header: String, output: Output): List<String> {
+        val lines = mutableListOf<String>()
+        fun String.cleanLine(): String  =
+            this.replace(colorRegex, "").trim()
+
+        // skip lines with numbers which show the source and skip the next ^^^^ line
+        if (output.peek()?.cleanLine()?.startsWith('|') == false) output.take(2)
+        while (output.nonEmpty() && output.peek()?.cleanLine()?.startsWith('|') == true) {
+            lines.add(output.take().cleanLine().removePrefix("|").trim())
+        }
+        lines.add(0, header)
+        return lines
+    }
+
+    private val IssuePositionMarker = """^[\s\|]*\^\s*$""".toRegex() // ^ surrounded by whitespace only
+
+    private fun tryFindColumnNumber(messageLines: List<String>): Int? {
+        val line = messageLines.find { IssuePositionMarker.matches(it.replace(colorRegex, "")) }
+        return line?.indexOf("^")?.let { it + 1 }
+    }
+}


### PR DESCRIPTION
Previously, Scala 3 diagnostics would not be shown since they currently use rendered message, which is a pretty printed diagnostic. Now, I added a separate parser for Scala 3 compiler diagnostics.

Related https://github.com/scalameta/metals/issues/6135