### PR TITLE
[feature] Resolve Scala SDK independently for each target

### DIFF
--- a/aspects/core.bzl
+++ b/aspects/core.bzl
@@ -38,8 +38,6 @@ COMPILE_DEPS = [
 
 PRIVATE_COMPILE_DEPS = [
     "_java_toolchain",
-    "_scala_toolchain",
-    "_scalac",
     "_jvm",
     "runtime_jdk",
 ]

--- a/aspects/core.bzl
+++ b/aspects/core.bzl
@@ -38,7 +38,6 @@ COMPILE_DEPS = [
 
 PRIVATE_COMPILE_DEPS = [
     "_java_toolchain",
-    "_scalac",
     "_jvm",
     "runtime_jdk",
 ]

--- a/aspects/core.bzl
+++ b/aspects/core.bzl
@@ -38,6 +38,7 @@ COMPILE_DEPS = [
 
 PRIVATE_COMPILE_DEPS = [
     "_java_toolchain",
+    "_scalac",
     "_jvm",
     "runtime_jdk",
 ]

--- a/aspects/rules/scala/scala_info.bzl
+++ b/aspects/rules/scala/scala_info.bzl
@@ -37,13 +37,13 @@ def extract_scala_info(target, ctx, output_groups, **kwargs):
 
     SCALA_TOOLCHAIN = "@io_bazel_rules_scala//scala:toolchain_type"
 
+    scala_info = {}
+
     # check of _scala_toolchain is necessary, because SCALA_TOOLCHAIN will always be present
     if hasattr(ctx.rule.attr, "_scala_toolchain"):
         common_scalac_opts = ctx.toolchains[SCALA_TOOLCHAIN].scalacopts
     else:
         common_scalac_opts = []
-    scalac_opts = common_scalac_opts + getattr(ctx.rule.attr, "scalacopts", [])
+    scala_info["scalac_opts"] = common_scalac_opts + getattr(ctx.rule.attr, "scalacopts", [])
 
-    scala_info = struct(scalac_opts = scalac_opts)
-
-    return create_proto(target, ctx, scala_info, "scala_target_info"), None
+    return create_proto(target, ctx, struct(**scala_info), "scala_target_info"), None

--- a/aspects/rules/scala/scala_info.bzl
+++ b/aspects/rules/scala/scala_info.bzl
@@ -1,4 +1,4 @@
-load("//aspects:utils/utils.bzl", "create_proto", "file_location", "is_external", "map", "update_sync_output_groups")
+load("//aspects:utils/utils.bzl", "create_proto", "file_location", "map")
 
 def find_scalac_classpath(runfiles):
     result = []
@@ -11,24 +11,6 @@ def find_scalac_classpath(runfiles):
         elif file.extension == "jar" and ("scala3-library" in name or "scala3-reflect" in name or "scala-library" in name or "scala-reflect" in name):
             result.append(file)
     return result if found_scala_compiler_jar and len(result) >= 2 else []
-
-def extract_scala_toolchain_info(target, ctx, output_groups, **kwargs):
-    runfiles = target.default_runfiles.files.to_list()
-
-    classpath = find_scalac_classpath(runfiles)
-
-    if not classpath:
-        return None, None
-
-    resolve_files = classpath
-    compiler_classpath = map(file_location, classpath)
-
-    if (is_external(target)):
-        update_sync_output_groups(output_groups, "external-deps-resolve", depset(resolve_files))
-
-    scala_toolchain_info = struct(compiler_classpath = compiler_classpath)
-
-    return create_proto(target, ctx, scala_toolchain_info, "scala_toolchain_info"), None
 
 def extract_scala_info(target, ctx, output_groups, **kwargs):
     kind = ctx.rule.kind

--- a/aspects/rules/scala/scala_info.bzl
+++ b/aspects/rules/scala/scala_info.bzl
@@ -42,6 +42,10 @@ def extract_scala_info(target, ctx, output_groups, **kwargs):
     # check of _scala_toolchain is necessary, because SCALA_TOOLCHAIN will always be present
     if hasattr(ctx.rule.attr, "_scala_toolchain"):
         common_scalac_opts = ctx.toolchains[SCALA_TOOLCHAIN].scalacopts
+        if hasattr(ctx.rule.attr, "_scalac"):
+            compiler_classpath = find_scalac_classpath(ctx.rule.attr._scalac.default_runfiles.files.to_list())
+            if compiler_classpath:
+                scala_info["compiler_classpath"] = map(file_location, compiler_classpath)
     else:
         common_scalac_opts = []
     scala_info["scalac_opts"] = common_scalac_opts + getattr(ctx.rule.attr, "scalacopts", [])

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspLanguageExtensionsGenerator.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspLanguageExtensionsGenerator.kt
@@ -12,7 +12,7 @@ enum class Language(private val fileName: String, val ruleNames: List<String>, v
   Java("//aspects:rules/java/java_info.bzl", listOf(), listOf("extract_java_toolchain", "extract_java_runtime"), false),
   Jvm("//aspects:rules/jvm/jvm_info.bzl", listOf(), listOf("extract_jvm_info"), false),
   Python("//aspects:rules/python/python_info.bzl", listOf(), listOf("extract_python_info"), false),
-  Scala("//aspects:rules/scala/scala_info.bzl", listOf("io_bazel_rules_scala"), listOf("extract_scala_info", "extract_scala_toolchain_info"), false),
+  Scala("//aspects:rules/scala/scala_info.bzl", listOf("io_bazel_rules_scala"), listOf("extract_scala_info"), false),
   Cpp("//aspects:rules/cpp/cpp_info.bzl", listOf("rules_cc"), listOf("extract_cpp_info"), false),
   Kotlin("//aspects:rules/kt/kt_info.bzl", listOf("io_bazel_rules_kotlin", "rules_kotlin"), listOf("extract_kotlin_info"), true),
   Rust("//aspects:rules/rust/rust_info.bzl", listOf("rules_rust"), listOf("extract_rust_crate_info"), false),

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/BazelProjectMapper.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/BazelProjectMapper.kt
@@ -180,29 +180,27 @@ class BazelProjectMapper(
   private fun calculateScalaLibrariesMapper(targetsToImport: Sequence<TargetInfo>): Map<String, List<Library>> {
     val projectLevelScalaSdkLibraries = calculateProjectLevelScalaLibraries()
     val scalaTargets = targetsToImport.filter { it.hasScalaTargetInfo() }.map { it.id }
-    return projectLevelScalaSdkLibraries
-      ?.let { libraries -> scalaTargets.associateWith { libraries } }
-      .orEmpty()
+    return scalaTargets.associateWith {
+      languagePluginsService.scalaLanguagePlugin.scalaSdks[it]?.compilerJars?.mapNotNull {
+        projectLevelScalaSdkLibraries[it]
+      }.orEmpty()
+    }
   }
 
-  private fun calculateProjectLevelScalaLibraries(): List<Library>? {
-    val scalaSdkLibrariesJars = getProjectLevelScalaSdkLibrariesJars()
-    return if (scalaSdkLibrariesJars.isNotEmpty()) {
-      scalaSdkLibrariesJars.map {
-        Library(
-          label = Paths.get(it).name,
-          outputs = setOf(it),
-          sources = emptySet(),
-          dependencies = emptyList()
-        )
-      }
-    } else null
-  }
+  private fun calculateProjectLevelScalaLibraries(): Map<URI, Library> =
+    getProjectLevelScalaSdkLibrariesJars().associateWith {
+      Library(
+        label = Paths.get(it).name,
+        outputs = setOf(it),
+        sources = emptySet(),
+        dependencies = emptyList()
+      )
+    }
 
   private fun getProjectLevelScalaSdkLibrariesJars(): Set<URI> =
-    languagePluginsService.scalaLanguagePlugin.scalaSdk
-      ?.compilerJars
-      ?.toSet().orEmpty()
+    languagePluginsService.scalaLanguagePlugin.scalaSdks.values.toSet().flatMap {
+      it.compilerJars
+    }.toSet()
 
   private fun calculateAndroidLibrariesMapper(targetsToImport: Sequence<TargetInfo>): Map<String, List<Library>> =
     targetsToImport.mapNotNull { target ->

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/TargetInfoReader.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/TargetInfoReader.kt
@@ -15,7 +15,6 @@ import org.jetbrains.bsp.bazel.info.BspTargetInfo.KotlinTargetInfo
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.PythonTargetInfo
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.RustCrateInfo
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.ScalaTargetInfo
-import org.jetbrains.bsp.bazel.info.BspTargetInfo.ScalaToolchainInfo
 import org.jetbrains.bsp.bazel.info.BspTargetInfo.TargetInfo
 import java.net.URI
 import java.nio.charset.StandardCharsets
@@ -76,12 +75,6 @@ class TargetInfoReader {
             val builder = readFromFile(path, ScalaTargetInfo.newBuilder())
             val info = builder.build()
             targetInfoBuilder.setScalaTargetInfo(info)
-        }
-
-        "scala_toolchain_info" -> {
-            val builder = readFromFile(path, ScalaToolchainInfo.newBuilder())
-            val info = builder.build()
-            targetInfoBuilder.setScalaToolchainInfo(info)
         }
 
         "kotlin_target_info" -> {

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaLanguagePlugin.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaLanguagePlugin.kt
@@ -36,7 +36,7 @@ class ScalaLanguagePlugin(
     }
 
     private fun <K, V> Map<K, V?>.filterValuesNotNull(): Map<K, V> =
-        filterValues{ it != null }.mapValues { it.value!! }
+        filterValues { it != null }.mapValues { it.value!! }
 
     override fun resolveModule(targetInfo: BspTargetInfo.TargetInfo): ScalaModule? {
         if (!targetInfo.hasScalaTargetInfo()) {

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaLanguagePlugin.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaLanguagePlugin.kt
@@ -26,24 +26,27 @@ class ScalaLanguagePlugin(
     private val bazelPathsResolver: BazelPathsResolver
 ) : LanguagePlugin<ScalaModule>() {
 
-    var scalaSdk: ScalaSdk? = null
+    var scalaSdks: Map<String, ScalaSdk> = emptyMap()
 
     override fun prepareSync(targets: Sequence<BspTargetInfo.TargetInfo>) {
-        scalaSdk = ScalaSdkResolver(bazelPathsResolver).resolve(targets)
+        scalaSdks = targets.associateBy(
+            { it.id },
+            ScalaSdkResolver(bazelPathsResolver)::resolveSdk
+        ).filterValuesNotNull()
     }
+
+    private fun <K, V> Map<K, V?>.filterValuesNotNull(): Map<K, V> =
+        filterValues{ it != null }.mapValues { it.value!! }
 
     override fun resolveModule(targetInfo: BspTargetInfo.TargetInfo): ScalaModule? {
         if (!targetInfo.hasScalaTargetInfo()) {
             return null
         }
         val scalaTargetInfo = targetInfo.scalaTargetInfo
-        val sdk = getScalaSdkOrThrow()
+        val sdk = scalaSdks[targetInfo.id] ?: return null
         val scalacOpts = scalaTargetInfo.scalacOptsList
         return ScalaModule(sdk, scalacOpts, javaLanguagePlugin.resolveModule(targetInfo))
     }
-
-    private fun getScalaSdkOrThrow(): ScalaSdk =
-        scalaSdk ?: throw RuntimeException("Failed to resolve Scala SDK for project")
 
     override fun dependencySources(
         targetInfo: BspTargetInfo.TargetInfo,

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaSdkResolver.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaSdkResolver.kt
@@ -15,13 +15,13 @@ class ScalaSdkResolver(private val bazelPathsResolver: BazelPathsResolver) {
             .sortedWith(SCALA_VERSION_COMPARATOR)
             .lastOrNull()
 
-    private fun resolveSdk(targetInfo: BspTargetInfo.TargetInfo): ScalaSdk? {
-        if (!targetInfo.hasScalaToolchainInfo()) {
+    fun resolveSdk(targetInfo: BspTargetInfo.TargetInfo): ScalaSdk? {
+        if (!targetInfo.hasScalaTargetInfo()) {
             return null
         }
-        val scalaToolchain = targetInfo.scalaToolchainInfo
+        val scalaTarget = targetInfo.scalaTargetInfo
         val compilerJars =
-            bazelPathsResolver.resolvePaths(scalaToolchain.compilerClasspathList).sorted()
+            bazelPathsResolver.resolvePaths(scalaTarget.compilerClasspathList).sorted()
         val maybeVersions = compilerJars.mapNotNull(::extractVersion)
         if (maybeVersions.none()) {
             return null

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaSdkResolver.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/scala/ScalaSdkResolver.kt
@@ -4,16 +4,8 @@ import org.jetbrains.bsp.bazel.info.BspTargetInfo
 import org.jetbrains.bsp.bazel.server.paths.BazelPathsResolver
 import java.nio.file.Path
 import java.util.regex.Pattern
-import kotlin.math.min
 
 class ScalaSdkResolver(private val bazelPathsResolver: BazelPathsResolver) {
-
-    fun resolve(targets: Sequence<BspTargetInfo.TargetInfo>): ScalaSdk? =
-        targets
-            .mapNotNull(::resolveSdk)
-            .distinct()
-            .sortedWith(SCALA_VERSION_COMPARATOR)
-            .lastOrNull()
 
     fun resolveSdk(targetInfo: BspTargetInfo.TargetInfo): ScalaSdk? {
         if (!targetInfo.hasScalaTargetInfo()) {
@@ -46,17 +38,6 @@ class ScalaSdkResolver(private val bazelPathsResolver: BazelPathsResolver) {
         version.split("\\.".toRegex()).toTypedArray().take(2).joinToString(".")
 
     companion object {
-        private val SCALA_VERSION_COMPARATOR = Comparator { a: ScalaSdk, b: ScalaSdk ->
-            val aParts = a.version.split("\\.".toRegex()).toTypedArray()
-            val bParts = b.version.split("\\.".toRegex()).toTypedArray()
-            var i = 0
-            while (i < min(aParts.size, bParts.size)) {
-                val result = aParts[i].toInt().compareTo(bParts[i].toInt())
-                if (result != 0) return@Comparator result
-                i++
-            }
-            0
-        }
         private val VERSION_PATTERN =
             Pattern.compile("(?:processed_)?scala3?-(?:library|compiler|reflect)(?:_3)?-([.\\d]+)\\.jar")
     }

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/proto/bsp_target_info.proto
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/proto/bsp_target_info.proto
@@ -49,6 +49,7 @@ message JavaRuntimeInfo {
 
 message ScalaTargetInfo {
   repeated string scalac_opts = 1;
+  repeated FileLocation compiler_classpath = 2;
 }
 
 message ScalaToolchainInfo {

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/proto/bsp_target_info.proto
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/proto/bsp_target_info.proto
@@ -52,10 +52,6 @@ message ScalaTargetInfo {
   repeated FileLocation compiler_classpath = 2;
 }
 
-message ScalaToolchainInfo {
-  repeated FileLocation compiler_classpath = 1;
-}
-
 message CppTargetInfo {
   repeated string copts = 1;
   repeated string defines = 2;
@@ -126,7 +122,6 @@ message TargetInfo {
   JavaToolchainInfo java_toolchain_info = 2000;
   JavaRuntimeInfo java_runtime_info = 3000;
   ScalaTargetInfo scala_target_info = 4000;
-  ScalaToolchainInfo scala_toolchain_info = 5000;
   CppTargetInfo cpp_target_info = 6000;
   KotlinTargetInfo kotlin_target_info = 7000;
   PythonTargetInfo python_target_info = 8000;

--- a/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspLanguageExtensionsGeneratorTest.kt
+++ b/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/bsp/managers/BazelBspLanguageExtensionsGeneratorTest.kt
@@ -54,8 +54,8 @@ class BazelBspLanguageExtensionsGeneratorTest {
             load("//aspects:rules/python/python_info.bzl","extract_python_info")
             load("//aspects:rules/cpp/cpp_info.bzl","extract_cpp_info")
             load("//aspects:rules/kt/kt_info.bzl","extract_kotlin_info")
-            load("//aspects:rules/scala/scala_info.bzl","extract_scala_info","extract_scala_toolchain_info")
-            EXTENSIONS=[extract_java_toolchain,extract_java_runtime,extract_jvm_info,extract_python_info,extract_cpp_info,extract_kotlin_info,extract_scala_info,extract_scala_toolchain_info]
+            load("//aspects:rules/scala/scala_info.bzl","extract_scala_info")
+            EXTENSIONS=[extract_java_toolchain,extract_java_runtime,extract_jvm_info,extract_python_info,extract_cpp_info,extract_kotlin_info,extract_scala_info]
             TOOLCHAINS=["@bazel_tools//tools/jdk:runtime_toolchain_type","@io_bazel_rules_kotlin//kotlin/internal:kt_toolchain_type","@io_bazel_rules_scala//scala:toolchain_type"]
         """.replace(" ", "").replace("\n", "")
     private val defaultRuleLanguages =


### PR DESCRIPTION
This prepares us for changes in `rules_scala` that will allow customizing the Scala version for each target.
In order to achieve that, we can no longer resolve the Scala SDK globally as the maximal version used. We need to use per-target info.
Scala SDK will be still discovered based on the compiler class path.
Now though we will look into an implicit dependency of each target, the `_scalac`.

This change is backward-compatible, as the mentioned data is already available.
It is also forward-compatible with the anticipated cross-build feature of `rules_scala`.
(see: https://github.com/bazelbuild/rules_scala/issues/1290)

The aspect will produce additional data – namely few compiler classpath jars per Scala target.
Perhaps we could review this change in the future to normalize the data back. Now it's not possible, as the data about alternative configurations (here: of scalac) is [discarded in the server](https://github.com/JetBrains/bazel-bsp/blob/75716956a6daad80cd2530e1e6dd0f7dc978854f/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/TargetInfoReader.kt#L52).