### PR TITLE
fix: Fix issues with warnings being cleared too soon

### DIFF
--- a/.teamcity/configurations/bazelBsp/bazelE2eTests.kts
+++ b/.teamcity/configurations/bazelBsp/bazelE2eTests.kts
@@ -67,6 +67,7 @@ object AndroidProjectTest : BazelBspE2ETestsBuildType(
 object ScalaProjectTest : BazelBspE2ETestsBuildType(
     targets = "//e2e:enabled_rules_test",
 )
+
 object AndroidKotlinProjectTest : BazelBspE2ETestsBuildType(
     targets = "//e2e:android_kotlin_project_test",
 )

--- a/e2e/src/main/kotlin/org/jetbrains/bsp/bazel/BazelBspScalaProjectTest.kt
+++ b/e2e/src/main/kotlin/org/jetbrains/bsp/bazel/BazelBspScalaProjectTest.kt
@@ -144,6 +144,8 @@ object BazelBspScalaProjectTest : BazelBspTestBaseScenario() {
 
     return BazelBspTestScenarioStep("compile results") {
       testClient.testCompile(60.seconds, compileParams, expectedCompilerResult, listOf(expectedDiagnosticsParam))
+      // second compile should not lose the diagnostics
+      testClient.testCompile(60.seconds, compileParams, expectedCompilerResult, listOf(expectedDiagnosticsParam))
     }
   }
 }

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bep/BepServer.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bep/BepServer.kt
@@ -284,7 +284,12 @@ class BepServer(
   }
 
   private fun consumeCompletedEvent(event: BuildEventStreamProtos.BuildEvent) {
-    val label = event.id.targetCompleted.label
+    val eventLabel = event.id.targetCompleted.label
+    /* The events never contain @, which will be different than the actual target id. Here we work around that fact,
+    * but since we also set up the BEP server to gather info about build targets within certain path (//... etc.), we can't
+    * just use target.uri. So this only fixes the diagnostics without breaking the query for targets.
+    * */
+    val label = if (target != null && ("@$eventLabel" == target.uri || "@@$eventLabel" == target.uri) ) target.uri else eventLabel
     val targetComplete = event.completed
     val outputGroups = targetComplete.outputGroupList
     LOGGER.trace("Consuming target completed event {}", targetComplete)

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsService.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsService.kt
@@ -34,13 +34,17 @@ class DiagnosticsService(workspaceRoot: Path, private val hasAnyProblems: Mutabl
     }
 
     fun clearFormerDiagnostics(targetLabel: String): List<PublishDiagnosticsParams> {
-	    val docs = hasAnyProblems[targetLabel]
+        val docs = hasAnyProblems[targetLabel]
 	    hasAnyProblems.remove(targetLabel)
-        if (updatedInThisRun.isNotEmpty()) {
-            hasAnyProblems[targetLabel] = updatedInThisRun.map { it.textDocument }.toSet()
+        val toClear = if (updatedInThisRun.isNotEmpty()) {
+            val updatedDocs = updatedInThisRun.map { it.textDocument }.toSet()
+            hasAnyProblems[targetLabel] = updatedDocs
             updatedInThisRun.clear()
+            docs?.subtract(updatedDocs)
+        } else {
+            docs
         }
-	    return docs
+	    return toClear
 	      ?.map { PublishDiagnosticsParams(it, BuildTargetIdentifier(targetLabel), emptyList(), true)}
 	      .orEmpty()
 	}


### PR DESCRIPTION
It seems that it was working at some point but somehow it stopped and I am not 100% sure why.

I noticed two issues currently:
- build target label is sometime missing @ so I add them to the label if we are currently in a target that has them
- the warnings would be cleared sine the build was successful, so remove files with warnings from being cleared.

I added a tests that tries to get the warnings twice in the same build whihc should test this properly.