### PR TITLE
bugfix: Don't send classpath if jvmClasspathReceiver is set to true

### DIFF
--- a/e2e/src/main/kotlin/org/jetbrains/bsp/bazel/BazelBspScalaProjectTest.kt
+++ b/e2e/src/main/kotlin/org/jetbrains/bsp/bazel/BazelBspScalaProjectTest.kt
@@ -27,9 +27,9 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 object BazelBspScalaProjectTest : BazelBspTestBaseScenario() {
-  private val testClient = createTestkitClient()
-  private val testClientClasspathReceiver = createTestkitClient(true)
   private val log = LogManager.getLogger(BazelBspScalaProjectTest::class.java)
+  private val testClient = createTestkitClient()
+  private val testClientClasspathReceiver = createTestkitClient(jvmClasspathReceiver = true)
 
   @JvmStatic
   fun main(args: Array<String>) = try{

--- a/e2e/src/main/kotlin/org/jetbrains/bsp/bazel/BazelBspScalaProjectTest.kt
+++ b/e2e/src/main/kotlin/org/jetbrains/bsp/bazel/BazelBspScalaProjectTest.kt
@@ -28,6 +28,7 @@ import kotlin.time.Duration.Companion.seconds
 
 object BazelBspScalaProjectTest : BazelBspTestBaseScenario() {
   private val testClient = createTestkitClient()
+  private val testClientClasspathReceiver = createTestkitClient(true)
   private val log = LogManager.getLogger(BazelBspScalaProjectTest::class.java)
 
   @JvmStatic
@@ -47,6 +48,7 @@ object BazelBspScalaProjectTest : BazelBspTestBaseScenario() {
       compareWorkspaceTargetsResults(),
       compileWithWarnings(),
       scalaOptionsResults(),
+      scalaOptionsResultsClasspathReceiver(),
   )
 
   private fun resolveProject(): BazelBspTestScenarioStep = BazelBspTestScenarioStep(
@@ -116,6 +118,22 @@ object BazelBspScalaProjectTest : BazelBspTestBaseScenario() {
     val scalaOptionsParams = ScalacOptionsParams(expectedTargetIdentifiers)
     return BazelBspTestScenarioStep("scalaOptions results") {
       testClient.testScalacOptions(120.seconds, scalaOptionsParams, expectedScalaOptionsResult)
+    }
+  }
+  private fun scalaOptionsResultsClasspathReceiver(): BazelBspTestScenarioStep {
+    val expectedTargetIdentifiers = expectedTargetIdentifiers().filter { it.uri != "bsp-workspace-root" }
+    val expectedScalaOptionsItems = expectedTargetIdentifiers.map {
+      ScalacOptionsItem(
+        it,
+        emptyList(),
+        emptyList(),
+        "file://\$BAZEL_OUTPUT_BASE_PATH/execroot/__main__/bazel-out/k8-fastbuild/bin/scala_targets/library.jar"
+      )
+    }
+    val expectedScalaOptionsResult = ScalacOptionsResult(expectedScalaOptionsItems)
+    val scalaOptionsParams = ScalacOptionsParams(expectedTargetIdentifiers)
+    return BazelBspTestScenarioStep("scalaOptions results") {
+      testClientClasspathReceiver.testScalacOptions(60.seconds, scalaOptionsParams, expectedScalaOptionsResult)
     }
   }
 

--- a/e2e/src/main/kotlin/org/jetbrains/bsp/bazel/base/BazelBspTestBaseScenario.kt
+++ b/e2e/src/main/kotlin/org/jetbrains/bsp/bazel/base/BazelBspTestBaseScenario.kt
@@ -79,11 +79,15 @@ abstract class BazelBspTestBaseScenario {
     }
   }
 
-  protected fun createTestkitClient(): TestClient {
+  protected fun createTestkitClient(): TestClient =
+    createTestkitClient(false)
+
+  protected fun createTestkitClient(jvmClasspathReceiver: Boolean): TestClient {
     log.info("Testing repo workspace path: $workspaceDir")
     log.info("Creating TestClient...")
 
     val capabilities = BuildClientCapabilities(listOf("java", "scala", "kotlin", "cpp"))
+    capabilities.jvmCompileClasspathReceiver = jvmClasspathReceiver
     val initializeBuildParams = InitializeBuildParams(
       "BspTestClient", "1.0.0", "2.0.0", workspaceDir, capabilities
     )

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/BspServerApi.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bsp/BspServerApi.kt
@@ -82,7 +82,8 @@ class BspServerApi(private val bazelServicesBuilder: (BuildClient) -> BazelServi
   ): CompletableFuture<InitializeBuildResult> {
     return runner.handleRequest("buildInitialize", { cancelChecker: CancelChecker ->
       projectSyncService.initialize(
-        cancelChecker
+        cancelChecker,
+        initializeBuildParams.capabilities,
       )
     }, { methodName: String ->
       runner.serverIsNotFinished(

--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ProjectSyncService.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ProjectSyncService.kt
@@ -42,15 +42,14 @@ import org.jetbrains.bsp.WorkspaceDirectoriesResult
 import org.jetbrains.bsp.WorkspaceInvalidTargetsResult
 import org.jetbrains.bsp.WorkspaceLibrariesResult
 import org.jetbrains.bsp.bazel.server.sync.model.Language
-import java.util.Optional
-import kotlin.jvm.optionals.getOrDefault
 
 /** A facade for all project sync related methods  */
 class ProjectSyncService(private val bspMapper: BspProjectMapper, private val projectProvider: ProjectProvider) {
 
-  private var clientCapabilities = Optional.empty<BuildClientCapabilities>()
-  fun initialize(cancelChecker: CancelChecker, clientCapabilities: BuildClientCapabilities): InitializeBuildResult{
-    this.clientCapabilities = Optional.of(clientCapabilities)
+  private lateinit var clientCapabilities: BuildClientCapabilities
+
+  fun initialize(cancelChecker: CancelChecker, clientCapabilities: BuildClientCapabilities): InitializeBuildResult {
+    this.clientCapabilities = clientCapabilities
     return bspMapper.initializeServer(Language.all())
   }
 
@@ -135,7 +134,7 @@ class ProjectSyncService(private val bspMapper: BspProjectMapper, private val pr
 
   fun buildTargetJavacOptions(cancelChecker: CancelChecker, params: JavacOptionsParams): JavacOptionsResult {
     val project = projectProvider.get(cancelChecker)
-    val includeClasspath = clientCapabilities.map { !it.jvmCompileClasspathReceiver }.getOrDefault(true)
+    val includeClasspath = !clientCapabilities.jvmCompileClasspathReceiver
     return bspMapper.buildTargetJavacOptions(project, params, includeClasspath, cancelChecker)
   }
 
@@ -151,7 +150,7 @@ class ProjectSyncService(private val bspMapper: BspProjectMapper, private val pr
 
   fun buildTargetScalacOptions(cancelChecker: CancelChecker, params: ScalacOptionsParams): ScalacOptionsResult {
     val project = projectProvider.get(cancelChecker)
-    val includeClasspath = clientCapabilities.map { !it.jvmCompileClasspathReceiver }.getOrDefault(true)
+    val includeClasspath = !clientCapabilities.jvmCompileClasspathReceiver
     return bspMapper.buildTargetScalacOptions(project, params, includeClasspath, cancelChecker)
   }
 


### PR DESCRIPTION
It seems that somehow I missed adding it in the previous PR, which baffles me greatly.

This makes sure that if the client wants to only receive classpath via jvmClasspath request then it's done properly.

I totally missed it in https://github.com/JetBrains/bazel-bsp/pull/542/files