### PR TITLE
[feature] include tool tag for all Bazel invocations

### DIFF
--- a/bazelrunner/src/main/kotlin/org/jetbrains/bsp/bazel/bazelrunner/BazelRunnerBuilder.kt
+++ b/bazelrunner/src/main/kotlin/org/jetbrains/bsp/bazel/bazelrunner/BazelRunnerBuilder.kt
@@ -3,6 +3,7 @@ package org.jetbrains.bsp.bazel.bazelrunner
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import com.google.common.collect.ImmutableList
 import org.jetbrains.bsp.bazel.bazelrunner.params.BazelQueryKindParameters
+import org.jetbrains.bsp.bazel.bazelrunner.params.BazelFlag
 import org.jetbrains.bsp.bazel.bazelrunner.utils.BazelArgumentsUtils
 import org.jetbrains.bsp.bazel.workspacecontext.TargetsSpec
 import java.nio.file.Path
@@ -11,8 +12,8 @@ open class BazelRunnerBuilder internal constructor(
     private val bazelRunner: BazelRunner,
     private val bazelCommand: List<String>,
 ) {
-
-    private val flags = mutableListOf<String>()
+    private val globalFlags = listOf<String>(BazelFlag.toolTag())
+    private val flags = globalFlags.toMutableList()
     private val arguments = mutableListOf<String>()
     private val environmentVariables = mutableMapOf<String, String>()
     private var useBuildFlags = false

--- a/bazelrunner/src/main/kotlin/org/jetbrains/bsp/bazel/bazelrunner/params/BUILD
+++ b/bazelrunner/src/main/kotlin/org/jetbrains/bsp/bazel/bazelrunner/params/BUILD
@@ -4,4 +4,7 @@ kt_jvm_library(
     name = "params",
     srcs = glob(["*.kt"]),
     visibility = ["//bazelrunner:__subpackages__"],
+    deps = [
+        "//commons",
+    ],
 )

--- a/bazelrunner/src/main/kotlin/org/jetbrains/bsp/bazel/bazelrunner/params/BazelFlag.kt
+++ b/bazelrunner/src/main/kotlin/org/jetbrains/bsp/bazel/bazelrunner/params/BazelFlag.kt
@@ -1,5 +1,8 @@
 package org.jetbrains.bsp.bazel.bazelrunner.params
 
+import org.jetbrains.bsp.bazel.commons.Constants.NAME
+import org.jetbrains.bsp.bazel.commons.Constants.VERSION
+
 object BazelFlag {
   @JvmStatic fun color(enabled: Boolean) =
       arg("color", if (enabled) "yes" else "no")
@@ -33,6 +36,9 @@ object BazelFlag {
 
   @JvmStatic fun start(startType: String): String =
     arg("start", startType)
+
+  @JvmStatic fun toolTag(): String =
+    arg("tool_tag", "$NAME:$VERSION")
 
   private fun arg(name: String, value: String) =
       String.format("--%s=%s", name, value)


### PR DESCRIPTION
Add a global tool_tag for all Bazel invocations from Bazel BSP, which will include the server name and version.  In setups where Bazel telemetry is collected, this will allow Bazel BSP invocations to be easily tracked and segmented out from other Bazel calls.

https://youtrack.jetbrains.com/issue/BAZEL-932