### PR TITLE
[fix] Allow arbitrary ending to Scala 3 error line

### DIFF
--- a/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/Scala3CompilerDiagnosticParser.kt
+++ b/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/Scala3CompilerDiagnosticParser.kt
@@ -10,7 +10,7 @@ object Scala3CompilerDiagnosticParser : Parser {
       \[E\d+\]   # "[E008]" code 
       ([^:]+): # (1) type of diagnostic
       ([^:]+):(\d+):(\d+) # (2) path, (3) line, (4) column
-      \ \-+$ # " -----------------" ending 
+      [\s-]*$ # " -----------------" ending 
       """.toRegex(RegexOption.COMMENTS)
 
     // Scala 3 diagnostics have additional color printed, since Bazel uses renderedMessage field


### PR DESCRIPTION
It turns out the ---- ending is not always showing up (or it changed) so improved the regex to account for that.